### PR TITLE
Allow overriding the message timestamp

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -102,6 +102,7 @@ Logger.prototype.log = function(statement, opts) {
             }
             message.level = opts.level || message.level;
             message.app = opts.app || message.app;
+            message.timestamp = opts.timestamp || message.timestamp;
             if (typeof opts.context === 'object') {
                 message.meta = opts.context;
             }


### PR DESCRIPTION
I'm writing a heroku drain receiver that filters log messages from all my apps before forwarding them to logdna. This change allows that service to use the original timestamps instead of the time at which the log was filtered.
