### PR TITLE
Encourage first time users to save `logdna`

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 ## Install
 
 ```javascript
-$ npm install logdna
+$ npm install --save logdna
 ```
 
 ## Setup


### PR DESCRIPTION
Encourage first time users/beginners to save the `logdna` package when installing to prevent issues with not having dependencies installed when deploying an application.