### PR TITLE
Improve SIGINT/SIGTERM handling

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -167,8 +167,8 @@ Logger.prototype._bufferLog = function(message) {
     }
 };
 
-Logger.prototype._flush = function() {
-    if (!this._req || this._buf.length === 0) { return; }
+Logger.prototype._flush = function(cb) {
+    if (!this._req || this._buf.length === 0) { cb && cb(); return; }
 
     var sendbuf = { e: 'ls', ls: this._buf };
     var data = stringify(sendbuf);
@@ -181,13 +181,14 @@ Logger.prototype._flush = function() {
         , qs: { now: Date.now() }
     }, function(err) {
         if (err) { debug('Encountered an Error in POST Request: %j', err); }
+        cb && cb(err);
     });
     clearTimeout(this._flusher);
     this._flusher = null;
 };
 
-Logger.prototype._cleanUp = function() {
-    this._flush();
+Logger.prototype._cleanUp = function(cb) {
+    this._flush(cb);
     for (var i = 0; i < loggers.length; i++) {
         if (_.isEqual(loggers[i].logger, this)) {
             loggers.splice(i, 1);
@@ -208,9 +209,13 @@ _.forEach(configs.LOG_LEVELS, function(level) {
     };
 });
 
-var flushAll = function() {
+var flushAll = function(cb) {
+    var expectedCallbacks = loggers.length;
+    function callback () {
+        if (expectedCallbacks-- < 1) cb();
+    }
     for (var i = 0; i < loggers.length; i++) {
-        loggers[i].logger._flush();
+        loggers[i].logger._flush(callback);
     }
 };
 
@@ -227,39 +232,26 @@ exports.createLogger = function(key, options) {
 };
 
 exports.flushAll = flushAll;
-exports.cleanUpAll = function() {
-    flushAll();
+exports.cleanUpAll = function(cb) {
+    flushAll(cb);
     loggers = [];
 };
 
-process.on('SIGTERM', function() {
+function onSignal(sigType) {
     var i = loggers.length;
-    while (i--) {
-        if (loggers[i].SIGTERM) {
-            loggers[i].logger._cleanUp();
-        }
-    }
-    var listeners = process.listeners('SIGTERM');
-    for (var x = listeners.length; x > 0; x--) {
-        if (listeners[x]) {
-            listeners[x]();
-        };
-    }
-    process.exit();
-});
-process.on('SIGINT', function() {
-    var i = loggers.length;
-    while (i--) {
-        if (loggers[i].SIGINT) {
-            loggers[i].logger._cleanUp();
-        }
-    }
-    var listeners = process.listeners('SIGINT');
-    for (var x = listeners.length; x > 0; x--) {
-        if (listeners[x]) {
-            listeners[x]();
-        };
-    }
-    process.exit();
-});
+    var finalize = process.listenerCount(sigType) > 1 ? function () {} : function () { process.exit(); };
 
+    var expectedCallbacks = 0;
+    function callback () {
+        if (expectedCallbacks-- < 1) finalize();
+    };
+    while (i--) {
+        if (loggers[i][sigType]) {
+            expectedCallbacks++;
+            loggers[i].logger._cleanUp(callback);
+        }
+    }
+}
+
+process.on('SIGTERM', onSignal.bind(null, 'SIGTERM'));
+process.on('SIGINT', onSignal.bind(null, 'SIGINT'));


### PR DESCRIPTION
Allow other SIGINT/SIGTERM listeners to handle process.exit().
Ensure that all requests finish before process exit.