### PR TITLE
Set withCredentials explicitly to support MeteorJS

### DIFF
--- a/lib/configs.js
+++ b/lib/configs.js
@@ -14,4 +14,5 @@ module.exports = {
     , LOGDNA_URL: (process.env.test === 'test') ? 'http://localhost:1337' : 'https://logs.logdna.com/logs/ingest'
     , MAC_ADDR_CHECK: /^([0-9a-fA-F][0-9a-fA-F]:){5}([0-9a-fA-F][0-9a-fA-F])$/
     , IP_ADDR_CHECK: /^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/
+    , REQUEST_WITH_CREDENTIALS: false
 };

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -93,6 +93,7 @@ function Logger(key, options) {
             , tags: this.source.tags
         }
         , timeout: options.timeout || configs.DEFAULT_REQUEST_TIMEOUT
+        , withCredentials: configs.REQUEST_WITH_CREDENTIALS
     });
     loggers.push(this);
 }


### PR DESCRIPTION
There is a CORS issue when using this library with Meteor.

`Failed to load https://logs.logdna.com/logs/ingest?hostname=localhost&now=1531324286589: Response to preflight request doesn't pass access control check: The value of the 'Access-Control-Allow-Origin' header in the response must not be the wildcard '*' when the request's credentials mode is 'include'. Origin 'http://localhost:3000' is therefore not allowed access. The credentials mode of requests initiated by the XMLHttpRequest is controlled by the withCredentials attribute.`

The same issue was reported in another library and was fixed by setting withCredentials to false explicitly.

https://github.com/GetStream/stream-js/issues/99

I tested the fix and was able to log normally after setting the withCredentials to false in the request made by this library.

This shouldn't have any effect on existing functionality and will fix the problem with Meteor.