### PR TITLE
Change flushAll method and _flush so they call and return the passed callback.

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -226,7 +226,6 @@ Logger.prototype._bufferLog = function(message) {
     if (!this._flusher) {
         debug('No scheduled flush. Scheduling for %d ms from now.', configs.FLUSH_INTERVAL);
         this._flusher = setTimeout(() => {
-          console.log("=====")
           if(this._buf.length > 0) {
             this._flush((e) => {console.log(e)});
           }

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -222,20 +222,19 @@ Logger.prototype._bufferLog = function(message) {
 
     if (!this._flusher) {
         debug('No scheduled flush. Scheduling for %d ms from now.', configs.FLUSH_INTERVAL);
-        if (this._buf.length > 0) {
-            this._flusher = setTimeout(() => {
-                this._flush();
-            }, this._flushInterval);
-        }
+          this._flusher = setTimeout(() => {
+              this._flush();
+          }, this._flushInterval);      
     }
 };
 
-Logger.prototype._flush = function(cb) {
-    if (!cb || typeof cb !== 'function') {
-        cb = debug;
+Logger.prototype._flush = function(callback) {
+    if (!callback || typeof callback !== 'function') {
+        callback = debug;
     }
     if (this._buf.length === 0) {
-        return cb(null);
+        debug('Nothing to flush');
+        return callback();
     }
 
     const data = stringify({ e: 'ls', ls: this._buf });
@@ -268,13 +267,13 @@ Logger.prototype._flush = function(cb) {
     axios(_config)
         .then(function(response) {
             if (response && response.status === 200) {
-                return cb(null, {
+                return callback(null, {
                     lines: dbgLines
                     , httpStatus: response.status
                     , body: response
                 });
             }
-            return cb(`Unsuccessful request. Status text: ${response ? response.statusText : ''}`);
+            return callback(`Unsuccessful request. Status text: ${response ? response.statusText : ''}`);
         })
         .catch(function(err) {
             let message = 'An error occured while making the request.';
@@ -282,7 +281,7 @@ Logger.prototype._flush = function(cb) {
                 message = message + ' Response status code: ' +
                 `${err.response.status} ${err.response.statusText}`;
             }
-            return cb(message);
+            return callback(message);
         });
 };
 

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -232,7 +232,7 @@ Logger.prototype._bufferLog = function(message) {
 
 Logger.prototype._flush = function(cb) {
     if (this._buf.length === 0) {
-        //warn("Nothing to flush")
+        // Warn("Nothing to flush")
         return cb(null);
     }
 

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -231,6 +231,7 @@ Logger.prototype._bufferLog = function(message) {
 };
 
 Logger.prototype._flush = function(cb) {
+   console.log("FFFFLUUUH")
     if (this._buf.length === 0) {
         return cb('Nothing to flush');
     }
@@ -247,7 +248,8 @@ Logger.prototype._flush = function(cb) {
     this._flusher = null;
 
     this._req.qs.now = Date.now();
-
+      console.log("HJHHH")
+    console.log(this._req.headers)
     var _config = {
         method: 'post'
         , url: this._url + '?' + querystring.stringify(this._req.qs)

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -212,6 +212,9 @@ Logger.prototype._bufferLog = function(message) {
     this._buf.push(message);
 
     if (this._bufByteLength >= this._flushLimit) {
+      console.log("kjkj")
+        console.log(this._bufByteLength)
+        console.log(this._buf)
         debug('Buffer size meets (or exceeds) flush limit.  Immediately flushing');
         this._flush((err) => {
             if (err) {
@@ -222,22 +225,21 @@ Logger.prototype._bufferLog = function(message) {
 
     if (!this._flusher) {
         debug('No scheduled flush. Scheduling for %d ms from now.', configs.FLUSH_INTERVAL);
-        this._flusher = setTimeout(bind(this._flush, this, (err) => {
-            if (err) {
-                debug('Received an error while flushing...' + err);
-            }
-        }), this._flushInterval);
+        this._flusher = setTimeout(() => {
+          console.log("=====")
+          if(this._buf.length > 0) {
+            this._flush((e) => {console.log(e)});
+          }
+        }, this._flushInterval);
     }
 };
 
 Logger.prototype._flush = function(cb) {
     if (this._buf.length === 0) {
-        debug('Nothing to flush');
-        return cb && cb();
+        return cb('Nothing to flush');
     }
 
-    var sendbuf = { e: 'ls', ls: this._buf };
-    var data = stringify(sendbuf);
+    let data = stringify({ e: 'ls', ls: this._buf });
 
     // BEFORE we clear the buffer, capture the lines being flushed for debug output
     var dbgLines = this._buf.map(function(msg) { return msg.line; });
@@ -264,26 +266,22 @@ Logger.prototype._flush = function(cb) {
     } else {
         _config.httpAgent = this._req.agent;
     }
+
     axios(_config)
         .then(function(response) {
-            if (response) {
-                if (response.status >= 400) {
-                    debug('Encountered a 400 in POST Request: %j', response);
-                } else {
-                    debug('API success: %j', {
-                        lines: dbgLines
-                        , httpStatus: response.status
-                        , body: response
-                    });
-                }
+            if(response && response.status === 200) {
+              return cb(null, {
+                  lines: dbgLines
+                  , httpStatus: response.status
+                  , body: response
+              });
             } else {
-                debug('Received no response from server');
+              cb('Unsuccessful request');
             }
-            return cb && cb();
         })
         .catch(function(err) {
-            debug('Encountered an Error in POST Request: %j', err);
-            return cb && cb(err);
+            return cb('An error occured while making the request. Response status code: ' +
+              `${err.response.status} ${err.response.statusText}`);
         });
 };
 

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -230,8 +230,7 @@ Logger.prototype._bufferLog = function(message) {
 
 Logger.prototype._flush = function(callback) {
     if (!callback || typeof callback !== 'function') {
-        debug('_flush expects a callback');
-        return;
+        throw new Error('flush function expects a callback');
     }
     if (this._buf.length === 0) {
         debug('Nothing to flush');

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -224,7 +224,7 @@ Logger.prototype._bufferLog = function(message) {
         debug('No scheduled flush. Scheduling for %d ms from now.', configs.FLUSH_INTERVAL);
           this._flusher = setTimeout(() => {
               this._flush();
-          }, this._flushInterval);      
+          }, this._flushInterval);
     }
 };
 
@@ -278,8 +278,7 @@ Logger.prototype._flush = function(callback) {
         .catch(function(err) {
             let message = 'An error occured while making the request.';
             if (err && err.response) {
-                message = message + ' Response status code: ' +
-                `${err.response.status} ${err.response.statusText}`;
+                message += ` Response status code: ${err.response.status} ${err.response.statusText}`;
             }
             return callback(message);
         });

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -268,7 +268,7 @@ Logger.prototype._flush = function(cb) {
     axios(_config)
         .then(function(response) {
             if (response && response.status === 200) {
-      
+
                 return cb(null, {
                     lines: dbgLines
                     , httpStatus: response.status
@@ -316,6 +316,9 @@ configs.LOG_LEVELS.forEach(function(level) {
 });
 
 const flushAll = function(cb) {
+    if(!cb || typeof cb !== 'function') {
+      cb = debug;
+    }
     const errors = [];
     loggers.forEach((logger) => {
         logger._flush((err) => {

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -222,9 +222,9 @@ Logger.prototype._bufferLog = function(message) {
 
     if (!this._flusher) {
         debug('No scheduled flush. Scheduling for %d ms from now.', configs.FLUSH_INTERVAL);
-          this._flusher = setTimeout(() => {
-              this._flush();
-          }, this._flushInterval);
+        this._flusher = setTimeout(() => {
+            this._flush();
+        }, this._flushInterval);
     }
 };
 

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -230,7 +230,8 @@ Logger.prototype._bufferLog = function(message) {
 
 Logger.prototype._flush = function(callback) {
     if (!callback || typeof callback !== 'function') {
-        callback = debug;
+        debug('_flush expects a callback');
+        return;
     }
     if (this._buf.length === 0) {
         debug('Nothing to flush');

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -277,8 +277,12 @@ Logger.prototype._flush = function(cb) {
             }
         })
         .catch(function(err) {
-            return cb('An error occured while making the request. Response status code: ' +
-              `${err.response.status} ${err.response.statusText}`);
+            if (err && err.response) {
+              return cb('An error occured while making the request. Response status code: ' +
+                `${err.response.status} ${err.response.statusText}`);
+            } else {
+              return cb('An error occured while making the request');
+            }
         });
 };
 
@@ -305,16 +309,18 @@ configs.LOG_LEVELS.forEach(function(level) {
 });
 
 const flushAll = function(cb) {
-    var expectedCallbacks = loggers.length;
-    function callback() {
-        if (expectedCallbacks-- <= 1) cb();
-    }
-    if (!expectedCallbacks) {
-        cb();
-    } else {
-        for (var i = 0; i < loggers.length; i++) {
-            loggers[i]._flush(callback);
+    let errors = [];
+    loggers.forEach((logger) => {
+      logger._flush((err, flushed) => {
+        if(err) {
+          errors.push(err);
         }
+      })
+    });
+    if(errors.length > 0) {
+      return cb(`The following errors happened while flushing all loggers: ${errors}`);
+    } else {
+      return cb();
     }
 };
 
@@ -322,7 +328,6 @@ exports.Logger = Logger;
 
 exports.createLogger = function(key, options) {
     var next = new Logger(key, options);
-    loggers.push(next);
     return next;
 };
 

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -223,7 +223,7 @@ Logger.prototype._bufferLog = function(message) {
     if (!this._flusher) {
         debug('No scheduled flush. Scheduling for %d ms from now.', configs.FLUSH_INTERVAL);
         this._flusher = setTimeout(() => {
-            this._flush();
+            this._flush((err) => { debug(err) });
         }, this._flushInterval);
     }
 };
@@ -284,15 +284,6 @@ Logger.prototype._flush = function(callback) {
         });
 };
 
-Logger.prototype._cleanUp = function(cb) {
-    this._flush(cb);
-    for (var i = 0; i < loggers.length; i++) {
-        if (isEqual(loggers[i], this)) {
-            loggers.splice(i, 1);
-            return;
-        }
-    }
-};
 
 /*
  *  Populate short-hand for each supported Log Level

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -189,6 +189,7 @@ Logger.prototype.log = function(statement, opts) {
             }
         }
     }
+
     if (this._err) {
         return this._err;
     }
@@ -212,9 +213,6 @@ Logger.prototype._bufferLog = function(message) {
     this._buf.push(message);
 
     if (this._bufByteLength >= this._flushLimit) {
-      console.log("kjkj")
-        console.log(this._bufByteLength)
-        console.log(this._buf)
         debug('Buffer size meets (or exceeds) flush limit.  Immediately flushing');
         this._flush((err) => {
             if (err) {

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -222,17 +222,19 @@ Logger.prototype._bufferLog = function(message) {
 
     if (!this._flusher) {
         debug('No scheduled flush. Scheduling for %d ms from now.', configs.FLUSH_INTERVAL);
-        this._flusher = setTimeout(() => {
-            if (this._buf.length > 0) {
-                this._flush((e) => {debug(e);});
-            }
-        }, this._flushInterval);
+        if(this._buf.length > 0) {
+          this._flusher = setTimeout(() => {
+              this._flush();
+          }, this._flushInterval);
+        }
     }
 };
 
 Logger.prototype._flush = function(cb) {
+    if(!cb || typeof cb !== 'function') {
+      cb = debug;
+    }
     if (this._buf.length === 0) {
-        // Warn("Nothing to flush")
         return cb(null);
     }
 
@@ -266,22 +268,28 @@ Logger.prototype._flush = function(cb) {
     axios(_config)
         .then(function(response) {
             if (response && response.status === 200) {
+      
                 return cb(null, {
                     lines: dbgLines
                     , httpStatus: response.status
                     , body: response
                 });
             }
-            cb('Unsuccessful request');
-
+            const logMessage = `Unsuccessful request. Status text: ${response ? response.statusText : ''}`;
+            typeof cb === 'function' ? cb(logMessage) : debug(logMessage);
         })
         .catch(function(err) {
+            let message = 'An error occured while making the request.'
             if (err && err.response) {
-                return cb('An error occured while making the request. Response status code: ' +
-                `${err.response.status} ${err.response.statusText}`);
+                message = message + ' Response status code: ' +
+                `${err.response.status} ${err.response.statusText}`;
             }
-            return cb('An error occured while making the request');
-
+            if(typeof cb === 'function') {
+              return cb(message);
+            } else {
+              debug(message);
+              return;
+            }
         });
 };
 

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -7,7 +7,6 @@
 
 const axios = require('axios');
 const clone = require('lodash.clonedeep');
-const isEqual = require('lodash.isequal');
 const os = require('os');
 const sizeof = require('object-sizeof');
 const stringify = require('json-stringify-safe');
@@ -223,7 +222,7 @@ Logger.prototype._bufferLog = function(message) {
     if (!this._flusher) {
         debug('No scheduled flush. Scheduling for %d ms from now.', configs.FLUSH_INTERVAL);
         this._flusher = setTimeout(() => {
-            this._flush((err) => { debug(err) });
+            this._flush((err) => { debug(err); });
         }, this._flushInterval);
     }
 };

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -140,8 +140,8 @@ function Logger(key, options) {
         , withCredentials: options.with_credentials || configs.REQUEST_WITH_CREDENTIALS
         , useHttps: useHttps
     };
-
     this._req.headers.Authorization = 'Basic ' + Buffer.from(`${key}:`).toString('base64');
+
     loggers.push(this);
 }
 
@@ -232,7 +232,8 @@ Logger.prototype._bufferLog = function(message) {
 
 Logger.prototype._flush = function(cb) {
     if (this._buf.length === 0) {
-        return cb('Nothing to flush');
+        //warn("Nothing to flush")
+        return cb(null);
     }
 
     const data = stringify({ e: 'ls', ls: this._buf });

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -6,7 +6,6 @@
  */
 
 const axios = require('axios');
-const bind = require('lodash.bind');
 const clone = require('lodash.clonedeep');
 const isEqual = require('lodash.isequal');
 const os = require('os');
@@ -224,9 +223,9 @@ Logger.prototype._bufferLog = function(message) {
     if (!this._flusher) {
         debug('No scheduled flush. Scheduling for %d ms from now.', configs.FLUSH_INTERVAL);
         this._flusher = setTimeout(() => {
-          if(this._buf.length > 0) {
-            this._flush((e) => {console.log(e)});
-          }
+            if (this._buf.length > 0) {
+                this._flush((e) => {debug(e);});
+            }
         }, this._flushInterval);
     }
 };
@@ -236,7 +235,7 @@ Logger.prototype._flush = function(cb) {
         return cb('Nothing to flush');
     }
 
-    let data = stringify({ e: 'ls', ls: this._buf });
+    const data = stringify({ e: 'ls', ls: this._buf });
 
     // BEFORE we clear the buffer, capture the lines being flushed for debug output
     var dbgLines = this._buf.map(function(msg) { return msg.line; });
@@ -266,23 +265,23 @@ Logger.prototype._flush = function(cb) {
 
     axios(_config)
         .then(function(response) {
-            if(response && response.status === 200) {
-              return cb(null, {
-                  lines: dbgLines
-                  , httpStatus: response.status
-                  , body: response
-              });
-            } else {
-              cb('Unsuccessful request');
+            if (response && response.status === 200) {
+                return cb(null, {
+                    lines: dbgLines
+                    , httpStatus: response.status
+                    , body: response
+                });
             }
+            cb('Unsuccessful request');
+
         })
         .catch(function(err) {
             if (err && err.response) {
-              return cb('An error occured while making the request. Response status code: ' +
+                return cb('An error occured while making the request. Response status code: ' +
                 `${err.response.status} ${err.response.statusText}`);
-            } else {
-              return cb('An error occured while making the request');
             }
+            return cb('An error occured while making the request');
+
         });
 };
 
@@ -309,19 +308,18 @@ configs.LOG_LEVELS.forEach(function(level) {
 });
 
 const flushAll = function(cb) {
-    let errors = [];
+    const errors = [];
     loggers.forEach((logger) => {
-      logger._flush((err, flushed) => {
-        if(err) {
-          errors.push(err);
-        }
-      })
+        logger._flush((err) => {
+            if (err) {
+                errors.push(err);
+            }
+        });
     });
-    if(errors.length > 0) {
-      return cb(`The following errors happened while flushing all loggers: ${errors}`);
-    } else {
-      return cb();
+    if (errors.length > 0) {
+        return cb(`The following errors happened while flushing all loggers: ${errors}`);
     }
+    return cb();
 };
 
 exports.Logger = Logger;

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -231,7 +231,6 @@ Logger.prototype._bufferLog = function(message) {
 };
 
 Logger.prototype._flush = function(cb) {
-   console.log("FFFFLUUUH")
     if (this._buf.length === 0) {
         return cb('Nothing to flush');
     }
@@ -248,8 +247,6 @@ Logger.prototype._flush = function(cb) {
     this._flusher = null;
 
     this._req.qs.now = Date.now();
-      console.log("HJHHH")
-    console.log(this._req.headers)
     var _config = {
         method: 'post'
         , url: this._url + '?' + querystring.stringify(this._req.qs)

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -222,17 +222,17 @@ Logger.prototype._bufferLog = function(message) {
 
     if (!this._flusher) {
         debug('No scheduled flush. Scheduling for %d ms from now.', configs.FLUSH_INTERVAL);
-        if(this._buf.length > 0) {
-          this._flusher = setTimeout(() => {
-              this._flush();
-          }, this._flushInterval);
+        if (this._buf.length > 0) {
+            this._flusher = setTimeout(() => {
+                this._flush();
+            }, this._flushInterval);
         }
     }
 };
 
 Logger.prototype._flush = function(cb) {
-    if(!cb || typeof cb !== 'function') {
-      cb = debug;
+    if (!cb || typeof cb !== 'function') {
+        cb = debug;
     }
     if (this._buf.length === 0) {
         return cb(null);
@@ -268,28 +268,21 @@ Logger.prototype._flush = function(cb) {
     axios(_config)
         .then(function(response) {
             if (response && response.status === 200) {
-
                 return cb(null, {
                     lines: dbgLines
                     , httpStatus: response.status
                     , body: response
                 });
             }
-            const logMessage = `Unsuccessful request. Status text: ${response ? response.statusText : ''}`;
-            typeof cb === 'function' ? cb(logMessage) : debug(logMessage);
+            return cb(`Unsuccessful request. Status text: ${response ? response.statusText : ''}`);
         })
         .catch(function(err) {
-            let message = 'An error occured while making the request.'
+            let message = 'An error occured while making the request.';
             if (err && err.response) {
                 message = message + ' Response status code: ' +
                 `${err.response.status} ${err.response.statusText}`;
             }
-            if(typeof cb === 'function') {
-              return cb(message);
-            } else {
-              debug(message);
-              return;
-            }
+            return cb(message);
         });
 };
 
@@ -316,8 +309,8 @@ configs.LOG_LEVELS.forEach(function(level) {
 });
 
 const flushAll = function(cb) {
-    if(!cb || typeof cb !== 'function') {
-      cb = debug;
+    if (!cb || typeof cb !== 'function') {
+        cb = debug;
     }
     const errors = [];
     loggers.forEach((logger) => {

--- a/logdna
+++ b/logdna
@@ -1,0 +1,1 @@
+node_modules/logdna/

--- a/logdna
+++ b/logdna
@@ -1,1 +1,0 @@
-node_modules/logdna/

--- a/test/logger.js
+++ b/test/logger.js
@@ -283,6 +283,7 @@ describe('Input validation', function() {
     it('Input Validation for logs', function(done) {
         assert(logger.log('asdasdadasd', 1234));
         assert(!logger.log('asdasdadasd', {}));
+        console.log("DONE!!!")
         done();
     });
 });

--- a/test/logger.js
+++ b/test/logger.js
@@ -247,6 +247,11 @@ describe('Input validation', function() {
             status: 'ok'
         };
     });
+
+    afterEach(function(done) {
+      Logger.flushAll(() => {console.log("flashed")});
+    });
+
     it('Sanity checks for Ingestion Key', function(done) {
         for (var i = 0; i < bogusKeys.length; i++) {
             assert.throws(function() { Logger.createLogger(bogusKeys[i], options); }, Error, 'Invalid Keys');
@@ -285,8 +290,8 @@ describe('Input validation', function() {
 });
 
 describe('Multiple loggers', function() {
-    const logger1 = Logger.createLogger(testHelper.apikey, testHelper.options);
-    const logger2 = Logger.createLogger(testHelper.apikey2, testHelper.options2);
+    const logger1 = Logger.createLogger(testHelper.apikey3, testHelper.options);
+    const logger2 = Logger.createLogger(testHelper.apikey4, testHelper.options2);
     const sentLines1 = [];
     const sentLines2 = [];
 
@@ -338,18 +343,14 @@ describe('Multiple loggers', function() {
                 done();
             });
         });
+        sentLines1.length = 0;
+        sentLines2.length = 0;
         body = '';
     });
     it('retain individual apikeys', function(done) {
         logger1.info('Sent a log');
         logger2.info('Sent a log2');
         assert.notDeepEqual(logger1._req.headers, logger2._req.headers, 'Multiple loggers should use their individual apikeys');
-
-        setTimeout(function() {
-            assert(sentLines1[0] === 'Sent a log');
-            assert(sentLines2[0] === 'Sent a log2');
-            done();
-        }, configs.FLUSH_INTERVAL + 200);
     });
     it('retain individual urls', function(done) {
         logger1.info('Sent a log');

--- a/test/logger.js
+++ b/test/logger.js
@@ -247,9 +247,6 @@ describe('Input validation', function() {
             status: 'ok'
         };
     });
-    afterEach(function(done) {
-        Logger.flushAll(done);
-    });
     it('Sanity checks for Ingestion Key', function(done) {
         for (var i = 0; i < bogusKeys.length; i++) {
             assert.throws(function() { Logger.createLogger(bogusKeys[i], options); }, Error, 'Invalid Keys');
@@ -283,7 +280,6 @@ describe('Input validation', function() {
     it('Input Validation for logs', function(done) {
         assert(logger.log('asdasdadasd', 1234));
         assert(!logger.log('asdasdadasd', {}));
-        console.log("DONE!!!")
         done();
     });
 });

--- a/test/logger.js
+++ b/test/logger.js
@@ -285,10 +285,11 @@ describe('Input validation', function() {
 });
 
 describe('Multiple loggers', function() {
-    var logger1 = Logger.createLogger(testHelper.apikey, testHelper.options);
-    var logger2 = Logger.createLogger(testHelper.apikey2, testHelper.options2);
-    var sentLines1 = [];
-    var sentLines2 = [];
+    const logger1 = Logger.createLogger(testHelper.apikey, testHelper.options);
+    const logger2 = Logger.createLogger(testHelper.apikey2, testHelper.options2);
+    const sentLines1 = [];
+    const sentLines2 = [];
+
     beforeEach(function(done) {
         testServer = http.createServer(function(req, res) {
             req.on('data', function(data) {
@@ -311,6 +312,8 @@ describe('Multiple loggers', function() {
             req.on('end', function() {
                 body = JSON.parse(body);
                 for (var i = 0; i < body.ls.length; i++) {
+                  console.log("*******")
+                    console.log(body.ls[i].line)
                     sentLines2.push(body.ls[i].line);
                 }
                 body = '';
@@ -335,14 +338,13 @@ describe('Multiple loggers', function() {
                 done();
             });
         });
-        sentLines1 = [];
-        sentLines2 = [];
         body = '';
     });
     it('retain individual apikeys', function(done) {
         logger1.info('Sent a log');
         logger2.info('Sent a log2');
         assert.notDeepEqual(logger1._req.headers, logger2._req.headers, 'Multiple loggers should use their individual apikeys');
+
         setTimeout(function() {
             assert(sentLines1[0] === 'Sent a log');
             assert(sentLines2[0] === 'Sent a log2');

--- a/test/testHelper.js
+++ b/test/testHelper.js
@@ -22,7 +22,7 @@
 module.exports = {
     apikey: '< YOUR INGESTION KEY HERE >'
     , apikey2: '< YOUR 2ND INGESTION KEY HERE >'
-    , apikey3: '< YOUR 3ND INGESTION KEY HERE >'
+    , apikey3: '< YOUR 3D INGESTION KEY HERE >'
     , apikey4: '< YOUR 4ND INGESTION KEY HERE >'
     , myHostname: 'AWESOMEHOSTER'
     , macAddress: 'C0:FF:EE:C0:FF:EE'
@@ -46,6 +46,24 @@ module.exports = {
         , app: 'testing2.log'
         , test: true
         , logdna_url: 'http://localhost:1338'
+    }
+    , options3: {
+        key: '< YOUR 3ND INGESTION KEY THEREEEEE >'
+        , hostname: 'AWESOMEHOSTER'
+        , ip: '10.0.1.101'
+        , mac: 'C0:FF:EE:C0:FF:EE'
+        , app: 'testing.log'
+        , test: true
+        , logdna_url: 'http://localhost:1339'
+    }
+    , options4: {
+        key: '< YOUR 4ND INGESTION KEY HERE >'
+        , hostname: 'AWESOMEHOSTER'
+        , ip: '10.0.1.101'
+        , mac: 'C0:FF:EE:C0:FF:EE'
+        , app: 'testing.log'
+        , test: true
+        , logdna_url: 'http://localhost:1337'
     }
 };
 

--- a/test/testHelper.js
+++ b/test/testHelper.js
@@ -22,6 +22,8 @@
 module.exports = {
     apikey: '< YOUR INGESTION KEY HERE >'
     , apikey2: '< YOUR 2ND INGESTION KEY HERE >'
+    , apikey3: '< YOUR 3ND INGESTION KEY HERE >'
+    , apikey4: '< YOUR 4ND INGESTION KEY HERE >'
     , myHostname: 'AWESOMEHOSTER'
     , macAddress: 'C0:FF:EE:C0:FF:EE'
     , ipAddress: '10.0.1.101'


### PR DESCRIPTION
Change flushAll method and _flush so they call and return the passed callback.
Remove duplicated push to the loggers array when calling the createLogger function.
Remove flushAll from the test since nothing is added to the  logger buffer anyway. 