### PR TITLE
Ambient Meta Support

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -148,7 +148,7 @@ function Logger(key, options) {
     loggers.push(this);
 }
 
-Logger.prototype.log = function (statement, opts) {
+Logger.prototype.log = function(statement, opts) {
     this._err = false;
     if (typeof statement === 'object') {
         if (this.ambientMeta) {

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -109,10 +109,6 @@ function Logger(key, options) {
         this._flushInterval = options.FLUSH_INTERVAL;
     }
 
-    if (options.custom && (typeof options.custom === 'string' || typeof options.custom === 'number')) {
-        this.custom = options.custom;
-    }
-
     this._max_length = options.max_length || true;
     this._index_meta = options.index_meta || false;
     this._url = options.logdna_url || configs.LOGDNA_URL;

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -155,7 +155,7 @@ Logger.prototype.log = function(statement, opts) {
     }
 
     if (typeof statement !== 'object' && this.ambientMeta) {
-        statement = `${JSON.stringify({message: statement, ambientMeta: this.ambientMeta})}`;
+        statement = `${JSON.stringify({message: statement, ambient_meta: this.ambientMeta})}`;
     }
 
     var message = {
@@ -236,11 +236,11 @@ Logger.prototype._bufferLog = function(message) {
     }
 };
 
-Logger.prototype.addAmbientMeta = function (meta) {
+Logger.prototype.addProperty = function (meta) {
     this.ambientMeta = meta;
 };
 
-Logger.prototype.removeAmbientMeta = function () {
+Logger.prototype.removeProperty = function () {
     this.ambientMeta = null;
 };
 

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -152,14 +152,14 @@ Logger.prototype.log = function (statement, opts) {
     this._err = false;
     if (typeof statement === 'object') {
         if (this.ambientMeta) {
-            statement['ambientMeta'] = this.ambientMeta;
-        }  
+            statement.ambientMeta = this.ambientMeta;
+        }
         statement = JSON.parse(JSON.stringify(statement));
         statement = stringify(statement, null, 2, function() { return undefined; });
     }
 
-    if(typeof statement !== 'object' && this.ambientMeta) {
-      statement = `${JSON.stringify({message: statement, ambientMeta: this.ambientMeta})}`;
+    if (typeof statement !== 'object' && this.ambientMeta) {
+        statement = `${JSON.stringify({message: statement, ambientMeta: this.ambientMeta})}`;
     }
 
     var message = {

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -109,6 +109,10 @@ function Logger(key, options) {
         this._flushInterval = options.FLUSH_INTERVAL;
     }
 
+    if (options.custom && (typeof options.custom === 'string' || typeof options.custom === 'number')) {
+        this.custom = options.custom;
+    }
+
     this._max_length = options.max_length || true;
     this._index_meta = options.index_meta || false;
     this._url = options.logdna_url || configs.LOGDNA_URL;
@@ -144,12 +148,20 @@ function Logger(key, options) {
     loggers.push(this);
 }
 
-Logger.prototype.log = function(statement, opts) {
+Logger.prototype.log = function (statement, opts) {
     this._err = false;
     if (typeof statement === 'object') {
+        if (this.ambientMeta) {
+            statement['ambientMeta'] = this.ambientMeta;
+        }  
         statement = JSON.parse(JSON.stringify(statement));
         statement = stringify(statement, null, 2, function() { return undefined; });
     }
+
+    if(typeof statement !== 'object' && this.ambientMeta) {
+      statement = `${JSON.stringify({message: statement, ambientMeta: this.ambientMeta})}`;
+    }
+
     var message = {
         timestamp: Date.now()
         , line: statement
@@ -157,6 +169,7 @@ Logger.prototype.log = function(statement, opts) {
         , app: this.source.app
         , env: this.source.env
     };
+
     if (opts) {
         if (typeof opts === 'string') {
             if (opts.length > configs.MAX_INPUT_LENGTH) {
@@ -225,6 +238,14 @@ Logger.prototype._bufferLog = function(message) {
             this._flush((err) => { debug(err); });
         }, this._flushInterval);
     }
+};
+
+Logger.prototype.addAmbientMeta = function (meta) {
+    this.ambientMeta = meta;
+};
+
+Logger.prototype.removeAmbientMeta = function () {
+    this.ambientMeta = null;
 };
 
 Logger.prototype._flush = function(callback) {

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -325,6 +325,7 @@ const flushAll = function(cb) {
             }
         });
     });
+
     if (errors.length > 0) {
         return cb(`The following errors happened while flushing all loggers: ${errors}`);
     }

--- a/test/logger.js
+++ b/test/logger.js
@@ -383,34 +383,35 @@ describe('ambient meta', function() {
     });
 
     it('add string ambinet meta to a string log line', function() {
-        ambientLogger.addAmbientMeta('someAmbientMeta');
+        ambientLogger.addProperty('someAmbientMeta');
         ambientLogger.log('Sent a string log');
         ambientLogger.log('Sent a second string log');
 
-        assert(ambientLogger._buf[0].line === '{"message":"Sent a string log","ambientMeta":"someAmbientMeta"}');
-        assert(ambientLogger._buf[1].line === '{"message":"Sent a second string log","ambientMeta":"someAmbientMeta"}');
+        assert(ambientLogger._buf[0].line === '{"message":"Sent a string log","ambient_meta":"someAmbientMeta"}');
+        assert(ambientLogger._buf[1].line === '{"message":"Sent a second string log","ambient_meta":"someAmbientMeta"}');
     });
     it('add an object ambinet meta to a string log line', function() {
-        ambientLogger.addAmbientMeta({someAmbientKey: 'value'});
+        ambientLogger.addProperty({someAmbientKey: 'value'});
 
         ambientLogger.log('Sent a string log');
         ambientLogger.log('Sent a second string log');
 
-        assert(ambientLogger._buf[0].line === '{"message":"Sent a string log","ambientMeta":{"someAmbientKey":"value"}}');
-        assert(ambientLogger._buf[1].line === '{"message":"Sent a second string log","ambientMeta":{"someAmbientKey":"value"}}');
+        assert(ambientLogger._buf[0].line === '{"message":"Sent a string log","ambient_meta":{"someAmbientKey":"value"}}');
+        assert(ambientLogger._buf[1].line === '{"message":"Sent a second string log","ambient_meta":{"someAmbientKey":"value"}}');
     });
     it('add an object ambinet meta to an object log line', function() {
-        ambientLogger.addAmbientMeta({someAmbientKey: 'value'});
+        ambientLogger.addProperty({someAmbientKey: 'value'});
 
         ambientLogger.log({k: 'v'});
-        assert(ambientLogger._buf[0].line === '{"message":"{\\n  \\"k\\": \\"v\\",\\n  \\"ambientMeta\\": {\\n    \\"someAmbientKey\\": \\"value\\"\\n  }\\n}","ambientMeta":{"someAmbientKey":"value"}}');
+
+        assert(ambientLogger._buf[0].line === '{"message":"{\\n  \\"k\\": \\"v\\",\\n  \\"ambientMeta\\": {\\n    \\"someAmbientKey\\": \\"value\\"\\n  }\\n}","ambient_meta":{"someAmbientKey":"value"}}');
     });
     it('remove ambient meta', function() {
-        ambientLogger.addAmbientMeta('someAmbientMeta');
+        ambientLogger.addProperty('someAmbientMeta');
         ambientLogger.log('Sent a string log');
-        ambientLogger.removeAmbientMeta();
+        ambientLogger.removeProperty();
         ambientLogger.log('Sent a string log');
-        assert(ambientLogger._buf[0].line === '{"message":"Sent a string log","ambientMeta":"someAmbientMeta"}');
+        assert(ambientLogger._buf[0].line === '{"message":"Sent a string log","ambient_meta":"someAmbientMeta"}');
         assert(ambientLogger._buf[1].line === 'Sent a string log');
     });
 });

--- a/test/logger.js
+++ b/test/logger.js
@@ -374,3 +374,40 @@ describe('Multiple loggers', function() {
         }, configs.FLUSH_INTERVAL + 200);
     });
 });
+
+describe('ambient meta', function() {
+  const ambientLogger = Logger.createLogger(testHelper.apikey, testHelper.options);
+
+  it('add string ambinet meta to a string log line', function() {
+      ambientLogger.addAmbientMeta('someAmbientMeta');
+      ambientLogger.log('Sent a string log');
+      ambientLogger.log('Sent a second string log');
+
+      assert(ambientLogger._buf[0].line === '{"message":"Sent a string log","ambientMeta":"someAmbientMeta"}');
+      assert(ambientLogger._buf[1].line === '{"message":"Sent a second string log","ambientMeta":"someAmbientMeta"}');
+  });
+  it('add an object ambinet meta to a string log line', function() {
+      ambientLogger.addAmbientMeta({someAmbientKey: 'value'});
+
+      ambientLogger.log('Sent a string log');
+      ambientLogger.log('Sent a second string log');
+
+      assert(ambientLogger._buf[0].line === '{"message":"Sent a string log","ambientMeta":{"someAmbientKey":"value"}}');
+      assert(ambientLogger._buf[1].line === '{"message":"Sent a second string log","ambientMeta":{"someAmbientKey":"value"}}');
+  });
+  it('add an object ambinet meta to an object log line', function() {
+      ambientLogger.addAmbientMeta({someAmbientKey: 'value'});
+
+      ambientLogger.log({k:'v'});
+
+      assert(ambientLogger._buf[0].line === '{"message":"{\\n  \\"k\\": \\"v\\",\\n  \\"ambientMeta\\": {\\n    \\"someAmbientKey\\": \\"value\\"\\n  }\\n}","ambientMeta":{"someAmbientKey":"value"}}');
+  });
+  it('remove ambient meta', function() {
+    ambientLogger.addAmbientMeta('someAmbientMeta');
+    ambientLogger.log('Sent a string log');
+    ambientLogger.removeAmbientMeta();
+    ambientLogger.log('Sent a string log');
+    assert(ambientLogger._buf[0].line === '{"message":"Sent a string log","ambientMeta":"someAmbientMeta"}');
+    assert(ambientLogger._buf[1].line === 'Sent a string log');
+  });
+});

--- a/test/logger.js
+++ b/test/logger.js
@@ -379,8 +379,8 @@ describe('ambient meta', function() {
     const ambientLogger = Logger.createLogger(testHelper.apikey, testHelper.options);
 
     beforeEach(function() {
-      Logger.flushAll();
-    })
+        Logger.flushAll();
+    });
 
     it('add string ambinet meta to a string log line', function() {
         ambientLogger.addAmbientMeta('someAmbientMeta');

--- a/test/logger.js
+++ b/test/logger.js
@@ -376,38 +376,38 @@ describe('Multiple loggers', function() {
 });
 
 describe('ambient meta', function() {
-  const ambientLogger = Logger.createLogger(testHelper.apikey, testHelper.options);
+    const ambientLogger = Logger.createLogger(testHelper.apikey, testHelper.options);
 
-  it('add string ambinet meta to a string log line', function() {
-      ambientLogger.addAmbientMeta('someAmbientMeta');
-      ambientLogger.log('Sent a string log');
-      ambientLogger.log('Sent a second string log');
+    it('add string ambinet meta to a string log line', function() {
+        ambientLogger.addAmbientMeta('someAmbientMeta');
+        ambientLogger.log('Sent a string log');
+        ambientLogger.log('Sent a second string log');
 
-      assert(ambientLogger._buf[0].line === '{"message":"Sent a string log","ambientMeta":"someAmbientMeta"}');
-      assert(ambientLogger._buf[1].line === '{"message":"Sent a second string log","ambientMeta":"someAmbientMeta"}');
-  });
-  it('add an object ambinet meta to a string log line', function() {
-      ambientLogger.addAmbientMeta({someAmbientKey: 'value'});
+        assert(ambientLogger._buf[0].line === '{"message":"Sent a string log","ambientMeta":"someAmbientMeta"}');
+        assert(ambientLogger._buf[1].line === '{"message":"Sent a second string log","ambientMeta":"someAmbientMeta"}');
+    });
+    it('add an object ambinet meta to a string log line', function() {
+        ambientLogger.addAmbientMeta({someAmbientKey: 'value'});
 
-      ambientLogger.log('Sent a string log');
-      ambientLogger.log('Sent a second string log');
+        ambientLogger.log('Sent a string log');
+        ambientLogger.log('Sent a second string log');
 
-      assert(ambientLogger._buf[0].line === '{"message":"Sent a string log","ambientMeta":{"someAmbientKey":"value"}}');
-      assert(ambientLogger._buf[1].line === '{"message":"Sent a second string log","ambientMeta":{"someAmbientKey":"value"}}');
-  });
-  it('add an object ambinet meta to an object log line', function() {
-      ambientLogger.addAmbientMeta({someAmbientKey: 'value'});
+        assert(ambientLogger._buf[0].line === '{"message":"Sent a string log","ambientMeta":{"someAmbientKey":"value"}}');
+        assert(ambientLogger._buf[1].line === '{"message":"Sent a second string log","ambientMeta":{"someAmbientKey":"value"}}');
+    });
+    it('add an object ambinet meta to an object log line', function() {
+        ambientLogger.addAmbientMeta({someAmbientKey: 'value'});
 
-      ambientLogger.log({k:'v'});
+        ambientLogger.log({k: 'v'});
 
-      assert(ambientLogger._buf[0].line === '{"message":"{\\n  \\"k\\": \\"v\\",\\n  \\"ambientMeta\\": {\\n    \\"someAmbientKey\\": \\"value\\"\\n  }\\n}","ambientMeta":{"someAmbientKey":"value"}}');
-  });
-  it('remove ambient meta', function() {
-    ambientLogger.addAmbientMeta('someAmbientMeta');
-    ambientLogger.log('Sent a string log');
-    ambientLogger.removeAmbientMeta();
-    ambientLogger.log('Sent a string log');
-    assert(ambientLogger._buf[0].line === '{"message":"Sent a string log","ambientMeta":"someAmbientMeta"}');
-    assert(ambientLogger._buf[1].line === 'Sent a string log');
-  });
+        assert(ambientLogger._buf[0].line === '{"message":"{\\n  \\"k\\": \\"v\\",\\n  \\"ambientMeta\\": {\\n    \\"someAmbientKey\\": \\"value\\"\\n  }\\n}","ambientMeta":{"someAmbientKey":"value"}}');
+    });
+    it('remove ambient meta', function() {
+        ambientLogger.addAmbientMeta('someAmbientMeta');
+        ambientLogger.log('Sent a string log');
+        ambientLogger.removeAmbientMeta();
+        ambientLogger.log('Sent a string log');
+        assert(ambientLogger._buf[0].line === '{"message":"Sent a string log","ambientMeta":"someAmbientMeta"}');
+        assert(ambientLogger._buf[1].line === 'Sent a string log');
+    });
 });

--- a/test/logger.js
+++ b/test/logger.js
@@ -378,6 +378,10 @@ describe('Multiple loggers', function() {
 describe('ambient meta', function() {
     const ambientLogger = Logger.createLogger(testHelper.apikey, testHelper.options);
 
+    beforeEach(function() {
+      Logger.flushAll();
+    })
+
     it('add string ambinet meta to a string log line', function() {
         ambientLogger.addAmbientMeta('someAmbientMeta');
         ambientLogger.log('Sent a string log');
@@ -399,7 +403,6 @@ describe('ambient meta', function() {
         ambientLogger.addAmbientMeta({someAmbientKey: 'value'});
 
         ambientLogger.log({k: 'v'});
-
         assert(ambientLogger._buf[0].line === '{"message":"{\\n  \\"k\\": \\"v\\",\\n  \\"ambientMeta\\": {\\n    \\"someAmbientKey\\": \\"value\\"\\n  }\\n}","ambientMeta":{"someAmbientKey":"value"}}');
     });
     it('remove ambient meta', function() {


### PR DESCRIPTION
Add methods that would add and remove an ambient meta property to a logger. The ambient meta can be either a string or an object. If it is an object, it has to be json  parseable and it will be parsed two levels deep and the rest will be stringified. (One of the levels is reserved for the 'ambientMeta' field)

If a logger which has an ambient meta sends a log message in a string representation, then that message will be transformed into an object: {message: {passed log line}, ambinetMeta: meta}.

If a logger which has an ambient meta sends a log message in an object representation, then this object will have an additional field - 'ambientMeta'. 

Note: Addressing #29 