### PR TITLE
HTTP Exception Handling

### DIFF
--- a/lib/configs.js
+++ b/lib/configs.js
@@ -15,4 +15,5 @@ module.exports = {
     , MAC_ADDR_CHECK: /^([0-9a-fA-F][0-9a-fA-F]:){5}([0-9a-fA-F][0-9a-fA-F])$/
     , IP_ADDR_CHECK: /^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/
     , REQUEST_WITH_CREDENTIALS: false
+    , FAILED_BUF_RETENTION_LIMIT: 10000
 };

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -239,13 +239,13 @@ Logger.prototype._sendRequest = function(_config, dbgInfoAndAttemps, callback) {
     axios(_config)
         .then(function(response) {
             if (response && response.status === 200) {
-                return {
+                return callback(null, return {
                     lines: dbgInfoAndAttemps.dbgLines
                     , httpStatus: response.status
                     , body: response
-                };
+                });
             }
-            return callback(`: ${response ? response.statusText : ''}`);
+            return callback(`The request is successful but returned status is: ${response ? response.statusText : ''}`);
         })
         .catch((err) => {
             if (dbgInfoAndAttemps.countAttempts < MAX_REQUEST_ATTEMPTS) {
@@ -255,7 +255,7 @@ Logger.prototype._sendRequest = function(_config, dbgInfoAndAttemps, callback) {
                 if (this._failedBuf.length < configs.FAILED_BUF_RETENTION_LIMIT) {
                     this._failedBuf = this._failedBuf.concat(JSON.parse(_config.data).ls);
                 }
-                return `Failed to send the following lines:. ${(err && err.response) ? err.response.statusText : ''}`;
+                return callback(`Failed to send the following lines: ${(err && err.response) ? err.response.statusText : ''}. We'll attemp to send them later`);
             }
         });
 };

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -115,7 +115,7 @@ function Logger(key, options) {
     this._url = options.logdna_url || configs.LOGDNA_URL;
     this._bufByteLength = 0;
     this._buf = [];
-    this._failedLines = [];
+    this._failedBuf = [];
     this._shouldResendFailedLines = false;
 
     this.source = {
@@ -194,6 +194,7 @@ Logger.prototype.log = function(statement, opts) {
     if (this._err) {
         return this._err;
     }
+
     this._bufferLog(message);
 };
 
@@ -212,6 +213,11 @@ Logger.prototype._bufferLog = function(message) {
 
     debug('Buffering message: %s', message.line);
     this._buf.push(message);
+
+    if (this._failedBuf.length > 0) {
+        this._buf = this._buf.concat(this._failedBuf);
+        this._failedBuf.length = 0;
+    }
 
     if (this._bufByteLength >= this._flushLimit) {
         debug('Buffer size meets (or exceeds) flush limit.  Immediately flushing');
@@ -247,8 +253,10 @@ Logger.prototype._sendRequest = function(_config, dbgLines, callback, countAttem
           if(countAttempts < MAX_REQUEST_ATTEMPTS) {
             this._sendRequest(_config, dbgLines, callback, ++countAttempts);
           } else {
-            this._failedLines = this._failedLines.concat(dbgLines);
-            return callback(`Failed to send the following lines: ${dbgLines}. ${(err && err.response) ? err.response.statusText: ''}`);
+            if (this._failedBuf.length < configs.FAILED_BUF_RETENTION_LIMIT) {
+              this._failedBuf = this._failedBuf.concat(JSON.parse(_config.data).ls);
+            }
+            return callback(`Failed to send the following lines:. ${(err && err.response) ? err.response.statusText: ''}`);
           }
       });
 }
@@ -265,7 +273,7 @@ Logger.prototype._flush = function(callback) {
     const data = stringify({ e: 'ls', ls: this._buf });
 
     // BEFORE we clear the buffer, capture the lines being flushed for debug output
-    var dbgLines = this._buf.map(function(msg) { return msg.line; });
+    const dbgLines = this._buf.map(function(msg) { return msg.line; });
 
     this._bufByteLength = 0;
     this._buf.length = 0;

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -227,6 +227,27 @@ Logger.prototype._bufferLog = function(message) {
     }
 };
 
+Logger.prototype.foo = function(_config, dbgLines, callback) {
+  axios(_config)
+      .then(function(response) {
+          if (response && response.status === 200) {
+              return callback(null, {
+                  lines: dbgLines
+                  , httpStatus: response.status
+                  , body: response
+              });
+          }
+          return callback(`Unsuccessful request. Status text: ${response ? response.statusText : ''}`);
+      })
+      .catch(function(err) {
+          console.log("hhh")
+          let message = 'An error occured while making the request.';
+          if (err && err.response) {
+              message += ` Response status code: ${err.response.status} ${err.response.statusText}`;
+          }
+          return callback(message);
+      });
+}
 Logger.prototype._flush = function(callback) {
     if (!callback || typeof callback !== 'function') {
         throw new Error('flush function expects a callback');
@@ -263,24 +284,7 @@ Logger.prototype._flush = function(callback) {
         _config.httpAgent = this._req.agent;
     }
 
-    axios(_config)
-        .then(function(response) {
-            if (response && response.status === 200) {
-                return callback(null, {
-                    lines: dbgLines
-                    , httpStatus: response.status
-                    , body: response
-                });
-            }
-            return callback(`Unsuccessful request. Status text: ${response ? response.statusText : ''}`);
-        })
-        .catch(function(err) {
-            let message = 'An error occured while making the request.';
-            if (err && err.response) {
-                message += ` Response status code: ${err.response.status} ${err.response.statusText}`;
-            }
-            return callback(message);
-        });
+    this.foo(_config, dbgLines, callback);
 };
 
 

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -239,7 +239,7 @@ Logger.prototype._sendRequest = function(_config, dbgInfoAndAttemps, callback) {
     axios(_config)
         .then(function(response) {
             if (response && response.status === 200) {
-                return callback(null, return {
+                return callback(null, {
                     lines: dbgInfoAndAttemps.dbgLines
                     , httpStatus: response.status
                     , body: response

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -236,30 +236,30 @@ Logger.prototype._bufferLog = function(message) {
     }
 };
 
-Logger.prototype._sendRequest = function(_config, dbgLines, callback, countAttempts) {
-  axios(_config)
-      .then(function(response) {
-          if (response && response.status === 200) {
-              return callback(null, {
-                  lines: dbgLines
-                  , httpStatus: response.status
-                  , body: response
-              });
-          }
-
-          return callback(`Unsuccessful request. Status text: ${response ? response.statusText : ''}`);
-      })
-      .catch((err) => {
-          if(countAttempts < MAX_REQUEST_ATTEMPTS) {
-            this._sendRequest(_config, dbgLines, callback, ++countAttempts);
-          } else {
-            if (this._failedBuf.length < configs.FAILED_BUF_RETENTION_LIMIT) {
-              this._failedBuf = this._failedBuf.concat(JSON.parse(_config.data).ls);
+Logger.prototype._sendRequest = function(_config, dbgInfoAndAttemps, callback) {
+    axios(_config)
+        .then(function(response) {
+            if (response && response.status === 200) {
+                return {
+                    lines: dbgInfoAndAttemps.dbgLines
+                    , httpStatus: response.status
+                    , body: response
+                };
             }
-            return callback(`Failed to send the following lines:. ${(err && err.response) ? err.response.statusText: ''}`);
-          }
-      });
-}
+            return callback(`: ${response ? response.statusText : ''}`);
+        })
+        .catch((err) => {
+            if (dbgInfoAndAttemps.countAttempts < MAX_REQUEST_ATTEMPTS) {
+                ++dbgInfoAndAttemps.countAttempts;
+                this._sendRequest(_config, dbgInfoAndAttemps, callback);
+            } else {
+                if (this._failedBuf.length < configs.FAILED_BUF_RETENTION_LIMIT) {
+                    this._failedBuf = this._failedBuf.concat(JSON.parse(_config.data).ls);
+                }
+                return `Failed to send the following lines:. ${(err && err.response) ? err.response.statusText : ''}`;
+            }
+        });
+};
 
 Logger.prototype._flush = function(callback) {
     if (!callback || typeof callback !== 'function') {
@@ -282,7 +282,7 @@ Logger.prototype._flush = function(callback) {
     this._flusher = null;
 
     this._req.qs.now = Date.now();
-    var _config = {
+    const _config = {
         method: 'post'
         , url: this._url + '?' + querystring.stringify(this._req.qs)
         , headers: this._req.headers
@@ -297,7 +297,7 @@ Logger.prototype._flush = function(callback) {
         _config.httpAgent = this._req.agent;
     }
 
-    this._sendRequest(_config, dbgLines, callback, 1);
+    this._sendRequest(_config, {dbgLines: dbgLines, countAttempts: 1}, callback);
 };
 
 

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -232,7 +232,7 @@ Logger.prototype.foo = function(_config, savedBuf, callback) {
       .then(function(response) {
           if (response && response.status === 200) {
               return callback(null, {
-                  lines: dbgLines
+                  lines: savedBuf
                   , httpStatus: response.status
                   , body: response
               });
@@ -240,7 +240,6 @@ Logger.prototype.foo = function(_config, savedBuf, callback) {
           return callback(`Unsuccessful request. Status text: ${response ? response.statusText : ''}`);
       })
       .catch(function(err) {
-          console.log("hhh")
           let message = 'An error occured while making the request.';
           if (err && err.response) {
               message += ` Response status code: ${err.response.status} ${err.response.statusText}`;
@@ -262,7 +261,6 @@ Logger.prototype._flush = function(callback) {
     // BEFORE we clear the buffer, capture the lines being flushed for debug output
     var dbgLines = this._buf.map(function(msg) { return msg.line; });
     const savedBuf = [...this._buf];
-
     this._bufByteLength = 0;
     this._buf.length = 0;
 

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -227,7 +227,7 @@ Logger.prototype._bufferLog = function(message) {
     }
 };
 
-Logger.prototype.foo = function(_config, dbgLines, callback) {
+Logger.prototype.foo = function(_config, savedBuf, callback) {
   axios(_config)
       .then(function(response) {
           if (response && response.status === 200) {
@@ -261,6 +261,7 @@ Logger.prototype._flush = function(callback) {
 
     // BEFORE we clear the buffer, capture the lines being flushed for debug output
     var dbgLines = this._buf.map(function(msg) { return msg.line; });
+    const savedBuf = [...this._buf];
 
     this._bufByteLength = 0;
     this._buf.length = 0;
@@ -284,7 +285,7 @@ Logger.prototype._flush = function(callback) {
         _config.httpAgent = this._req.agent;
     }
 
-    this.foo(_config, dbgLines, callback);
+    this.foo(_config, savedBuf, callback);
 };
 
 

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -194,7 +194,6 @@ Logger.prototype.log = function(statement, opts) {
     if (this._err) {
         return this._err;
     }
-
     this._bufferLog(message);
 };
 

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -19,6 +19,7 @@ const util = require('util');
 const debug = util.debuglog('logdna');
 
 const configs = require('./configs');
+const MAX_REQUEST_ATTEMPTS = 3;
 
 var loggers = [];
 
@@ -114,6 +115,7 @@ function Logger(key, options) {
     this._url = options.logdna_url || configs.LOGDNA_URL;
     this._bufByteLength = 0;
     this._buf = [];
+    this._failedBuffer = [];
 
     this.source = {
         hostname: options.hostname || os.hostname()
@@ -227,26 +229,32 @@ Logger.prototype._bufferLog = function(message) {
     }
 };
 
-Logger.prototype.foo = function(_config, savedBuf, callback) {
+Logger.prototype._sendRequest = function(_config, dbgLines, callback, countAttempts) {
   axios(_config)
       .then(function(response) {
           if (response && response.status === 200) {
               return callback(null, {
-                  lines: savedBuf
+                  lines: dbgLines
                   , httpStatus: response.status
                   , body: response
               });
           }
+          this._failedBuffer = 0;
           return callback(`Unsuccessful request. Status text: ${response ? response.statusText : ''}`);
       })
-      .catch(function(err) {
-          let message = 'An error occured while making the request.';
-          if (err && err.response) {
-              message += ` Response status code: ${err.response.status} ${err.response.statusText}`;
+      .catch((err) => {
+          if(countAttempts < 3) {
+            this._sendRequest(_config, dbgLines, callback, ++countAttempts);
+          } else {
+            let message = 'An error occured while making the request.';
+            if (err && err.response) {
+                message += ` Response status code: ${err.response.status} ${err.response.statusText}`;
+            }
+            return callback(message);
           }
-          return callback(message);
       });
 }
+
 Logger.prototype._flush = function(callback) {
     if (!callback || typeof callback !== 'function') {
         throw new Error('flush function expects a callback');
@@ -260,7 +268,7 @@ Logger.prototype._flush = function(callback) {
 
     // BEFORE we clear the buffer, capture the lines being flushed for debug output
     var dbgLines = this._buf.map(function(msg) { return msg.line; });
-    const savedBuf = [...this._buf];
+    this._failedBuffer.concat([...this._buf]);
     this._bufByteLength = 0;
     this._buf.length = 0;
 
@@ -283,7 +291,7 @@ Logger.prototype._flush = function(callback) {
         _config.httpAgent = this._req.agent;
     }
 
-    this.foo(_config, savedBuf, callback);
+    this._sendRequest(_config, dbgLines, callback, 0);
 };
 
 

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -115,7 +115,8 @@ function Logger(key, options) {
     this._url = options.logdna_url || configs.LOGDNA_URL;
     this._bufByteLength = 0;
     this._buf = [];
-    this._failedBuffer = [];
+    this._failedLines = [];
+    this._shouldResendFailedLines = false;
 
     this.source = {
         hostname: options.hostname || os.hostname()
@@ -239,18 +240,15 @@ Logger.prototype._sendRequest = function(_config, dbgLines, callback, countAttem
                   , body: response
               });
           }
-          this._failedBuffer = 0;
+
           return callback(`Unsuccessful request. Status text: ${response ? response.statusText : ''}`);
       })
       .catch((err) => {
-          if(countAttempts < 3) {
+          if(countAttempts < MAX_REQUEST_ATTEMPTS) {
             this._sendRequest(_config, dbgLines, callback, ++countAttempts);
           } else {
-            let message = 'An error occured while making the request.';
-            if (err && err.response) {
-                message += ` Response status code: ${err.response.status} ${err.response.statusText}`;
-            }
-            return callback(message);
+            this._failedLines = this._failedLines.concat(dbgLines);
+            return callback(`Failed to send the following lines: ${dbgLines}. ${(err && err.response) ? err.response.statusText: ''}`);
           }
       });
 }
@@ -268,7 +266,7 @@ Logger.prototype._flush = function(callback) {
 
     // BEFORE we clear the buffer, capture the lines being flushed for debug output
     var dbgLines = this._buf.map(function(msg) { return msg.line; });
-    this._failedBuffer.concat([...this._buf]);
+
     this._bufByteLength = 0;
     this._buf.length = 0;
 
@@ -291,7 +289,7 @@ Logger.prototype._flush = function(callback) {
         _config.httpAgent = this._req.agent;
     }
 
-    this._sendRequest(_config, dbgLines, callback, 0);
+    this._sendRequest(_config, dbgLines, callback, 1);
 };
 
 

--- a/test/logger.js
+++ b/test/logger.js
@@ -149,7 +149,7 @@ describe('Testing for Correctness', function() {
         sentLines = [];
         body = '';
     });
-    it('Exact Matches and Proper Order', function(done) {
+    it.only('Exact Matches and Proper Order', function(done) {
         var p = testHelper.memoryChecker(sendLogs);
         p.then(() => {
             assert(testHelper.arraysEqual(ordered, sentLines));

--- a/test/logger.js
+++ b/test/logger.js
@@ -379,6 +379,8 @@ describe('HTTP Excpetion handling', function() {
     let countHits = 0;
     let statusCode = 302;
     let edgeCaseFlag = false;
+    const port = 1336;
+    const options = testHelper.createOptions({port: port});
 
     beforeEach(function(done) {
         httpExcServer = http.createServer(function(req, res) {
@@ -390,7 +392,7 @@ describe('HTTP Excpetion handling', function() {
             res.end(() => {++countHits;});
         });
         httpExcServer.on('listening', done);
-        httpExcServer.listen(1337);
+        httpExcServer.listen(port);
     });
 
     afterEach(function(done) {
@@ -405,7 +407,7 @@ describe('HTTP Excpetion handling', function() {
         statusCode = 302;
     });
     it('should try to reconnect if response was unsuccessful and after 3 attemps, save the lines in the array', function(done) {
-        const httpExcLogger = Logger.createLogger(testHelper.apikey, testHelper.options);
+        const httpExcLogger = Logger.createLogger(testHelper.apikey, options);
         httpExcLogger.debug('Will try 3 times', { meta: { extra_info: 'extra info' }});
         httpExcLogger.debug('Will try 3 times', { meta: { extra_info: 'extra info' }});
         setTimeout(function() {
@@ -417,7 +419,7 @@ describe('HTTP Excpetion handling', function() {
     });
     it('when first attempt fails and second succeeds, it should clean failed lines array', function(done) {
         edgeCaseFlag = true;
-        const httpExcLogger = Logger.createLogger(testHelper.apikey, testHelper.options);
+        const httpExcLogger = Logger.createLogger(testHelper.apikey, options);
         httpExcLogger.debug('Will try 3 times', { meta: { extra_info: 'extra info' }});
         httpExcLogger.debug('Will try 3 times', { meta: { extra_info: 'extra info' }});
         setTimeout(function() {
@@ -428,7 +430,7 @@ describe('HTTP Excpetion handling', function() {
     });
     it('should not save the lines in the failed lines array when succeeds', function(done) {
         statusCode = 200;
-        const httpExcLogger = Logger.createLogger(testHelper.apikey, testHelper.options);
+        const httpExcLogger = Logger.createLogger(testHelper.apikey, options);
         httpExcLogger.debug('Will try 3 times', { meta: { extra_info: 'extra info' }});
         httpExcLogger.debug('Will try 3 times', { meta: { extra_info: 'extra info' }});
         setTimeout(function() {

--- a/test/logger.js
+++ b/test/logger.js
@@ -149,7 +149,7 @@ describe('Testing for Correctness', function() {
         sentLines = [];
         body = '';
     });
-    it.only('Exact Matches and Proper Order', function(done) {
+    it('Exact Matches and Proper Order', function(done) {
         var p = testHelper.memoryChecker(sendLogs);
         p.then(() => {
             assert(testHelper.arraysEqual(ordered, sentLines));

--- a/test/testHelper.js
+++ b/test/testHelper.js
@@ -91,21 +91,21 @@ module.exports.arraysEqual = function(a, b) {
     return true;
 };
 module.exports.createOptions = function({
-  key = '< YOUR INGESTION KEY HERE >'
-  , hostname = 'AWESOMEHOSTER'
-  , ip = '10.0.1.101'
-  , mac = 'C0:FF:EE:C0:FF:EE'
-  , app ='testing.log'
-  , test = true
-  , port = 1337
+    key = '< YOUR INGESTION KEY HERE >'
+    , hostname = 'AWESOMEHOSTER'
+    , ip = '10.0.1.101'
+    , mac = 'C0:FF:EE:C0:FF:EE'
+    , app = 'testing.log'
+    , test = true
+    , port = 1337
 } = {}) {
-  return {
-    key: key
-    , hostname: hostname
-    , ip: ip
-    , mac: mac
-    , app: app
-    , test: test
-    , logdna_url: `http://localhost:${port}`
-  };
+    return {
+        key: key
+        , hostname: hostname
+        , ip: ip
+        , mac: mac
+        , app: app
+        , test: test
+        , logdna_url: `http://localhost:${port}`
+    };
 };

--- a/test/testHelper.js
+++ b/test/testHelper.js
@@ -90,3 +90,22 @@ module.exports.arraysEqual = function(a, b) {
     }
     return true;
 };
+module.exports.createOptions = function({
+  key = '< YOUR INGESTION KEY HERE >'
+  , hostname = 'AWESOMEHOSTER'
+  , ip = '10.0.1.101'
+  , mac = 'C0:FF:EE:C0:FF:EE'
+  , app ='testing.log'
+  , test = true
+  , port = 1337
+} = {}) {
+  return {
+    key: key
+    , hostname: hostname
+    , ip: ip
+    , mac: mac
+    , app: app
+    , test: test
+    , logdna_url: `http://localhost:${port}`
+  };
+};


### PR DESCRIPTION
If logger receives an unsuccessful response, it will try to reconnect with the server 3 times. If it still fails, it will save the buffer on the logger instance and when the next time when a new message is pushed into buffer, it will merge the current buffer with the unsend content of the previous buffer. 
When it merges the unsent info with the current buffer, it cleans the temp holder for the unsent info. 
The holder for the unsent info has a limit to grow