### PR TITLE
Enable certain properties to be specified outside of the message line

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -207,15 +207,15 @@ Logger.prototype.log = function(statement, opts) {
             }
 
             if (opts.logSourceCRN) {
-              message.logSourceCRN = opts.logSourceCRN
+                message.logSourceCRN = opts.logSourceCRN;
             }
 
             if (opts.saveServiceCopy) {
-              message.saveServiceCopy = opts.saveServiceCopy
+                message.saveServiceCopy = opts.saveServiceCopy;
             }
 
             if (opts.appOverride) {
-              message.appOverride = opts.appOverride
+                message.appOverride = opts.appOverride;
             }
         }
     } else if (!this._index_meta) {

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -205,6 +205,18 @@ Logger.prototype.log = function(statement, opts) {
                     message.meta = stringify(opts.meta);
                 }
             }
+
+            if (opts.logSourceCRN) {
+              message.logSourceCRN = opts.logSourceCRN
+            }
+
+            if (opts.saveServiceCopy) {
+              message.saveServiceCopy = opts.saveServiceCopy
+            }
+
+            if (opts.appOverride) {
+              message.appOverride = opts.appOverride
+            }
         }
     } else if (!this._index_meta) {
         message.meta = stringify(message.meta);


### PR DESCRIPTION
To support supertenancy options with LogDNA on IBM Cloud:
- appOverride: control on the %app field instead of it converting to the CRN in a supertenant receiver
- logSourceCRN: specify the CRN of the end user instance outside of the message body
- saveServiceCopy: specify whether to keep a copy of the message in the STS outside of the message body