### PR TITLE
Adds callback parameter to the  `log` and other functions.

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -370,7 +370,7 @@ configs.LOG_LEVELS.forEach(function(level) {
             callback = opts;
             opts = {};
         }
-        if (!opts) opts = {};
+        opts = opts || {};
         opts.level = level;
 
         this.log(statement, opts, callback);

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -174,7 +174,7 @@ Logger.prototype.log = function(statement, opts, callback) {
 
     if (opts) {
         if (typeof opts === 'function') {
-          callback = opts;
+            callback = opts;
         } else if (typeof opts === 'string') {
             if (opts.length > configs.MAX_INPUT_LENGTH) {
                 debug('Level had more than ' + configs.MAX_INPUT_LENGTH + ' chars, was truncated');
@@ -186,7 +186,7 @@ Logger.prototype.log = function(statement, opts, callback) {
                 this._err = true;
                 debug('Can only pass a String or JSON object as additional parameter');
             }
-          
+
             message.level = opts.level || message.level;
             message.app = opts.app || message.app;
             message.env = opts.env || message.env;
@@ -238,7 +238,7 @@ Logger.prototype._bufferLog = function(message, callback) {
     }
 
     if (!callback || typeof callback !== 'function') {
-        callback = () => {};
+        callback = (err) => {debug(err);};
     }
 
     if (this._max_length && message.line.length > configs.MAX_LINE_LENGTH) {
@@ -366,11 +366,11 @@ Logger.prototype._flush = function(callback) {
 configs.LOG_LEVELS.forEach(function(level) {
     var levelFuncationName = level.toLowerCase();
     Logger.prototype[levelFuncationName] = function(statement, opts, callback) {
-        if(opts && typeof opts === 'function') {
-          callback = opts;
-          opts = {};
+        if (opts && typeof opts === 'function') {
+            callback = opts;
+            opts = {};
         }
-        if(!opts) opts = {};
+        if (!opts) opts = {};
         opts.level = level;
 
         this.log(statement, opts, callback);

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -238,7 +238,7 @@ Logger.prototype._bufferLog = function(message, callback) {
     }
 
     if (!callback || typeof callback !== 'function') {
-        callback = (err) => {debug(err);};
+        callback = (err) => { debug(err); };
     }
 
     if (this._max_length && message.line.length > configs.MAX_LINE_LENGTH) {

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -156,7 +156,7 @@ function Logger(key, options) {
     loggers.push(this);
 }
 
-Logger.prototype.log = function(statement, opts) {
+Logger.prototype.log = function(statement, opts, callback) {
     this._err = false;
     if (typeof statement === 'object') {
         statement = JSON.parse(JSON.stringify(statement));
@@ -173,7 +173,9 @@ Logger.prototype.log = function(statement, opts) {
     };
 
     if (opts) {
-        if (typeof opts === 'string') {
+        if (typeof opts === 'function') {
+          callback = opts;
+        } else if (typeof opts === 'string') {
             if (opts.length > configs.MAX_INPUT_LENGTH) {
                 debug('Level had more than ' + configs.MAX_INPUT_LENGTH + ' chars, was truncated');
                 opts = opts.substring(0, configs.MAX_INPUT_LENGTH);
@@ -184,7 +186,7 @@ Logger.prototype.log = function(statement, opts) {
                 this._err = true;
                 debug('Can only pass a String or JSON object as additional parameter');
             }
-
+          
             message.level = opts.level || message.level;
             message.app = opts.app || message.app;
             message.env = opts.env || message.env;
@@ -226,13 +228,17 @@ Logger.prototype.log = function(statement, opts) {
         return this._err;
     }
 
-    this._bufferLog(message);
+    this._bufferLog(message, callback);
 };
 
-Logger.prototype._bufferLog = function(message) {
+Logger.prototype._bufferLog = function(message, callback) {
     if (!message || !message.line) {
         debug('Ignoring empty message');
         return;
+    }
+
+    if (!callback || typeof callback !== 'function') {
+        callback = () => {};
     }
 
     if (this._max_length && message.line.length > configs.MAX_LINE_LENGTH) {
@@ -263,14 +269,14 @@ Logger.prototype._bufferLog = function(message) {
         debug('Backing off.');
         this._isLoggingBackedOff = false;
         this._flusher = setTimeout(() => {
-            this._flush((err) => { debug(err); });
+            this._flush(callback);
         }, this._retryTimeout);
     }
 
     if (!this._flusher) {
         debug('No scheduled flush. Scheduling for %d ms from now.', configs.FLUSH_INTERVAL);
         this._flusher = setTimeout(() => {
-            this._flush((err) => { debug(err); });
+            this._flush(callback);
         }, this._flushInterval);
     }
 };
@@ -358,11 +364,16 @@ Logger.prototype._flush = function(callback) {
  *  Populate short-hand for each supported Log Level
  */
 configs.LOG_LEVELS.forEach(function(level) {
-    var l = level.toLowerCase();
-    Logger.prototype[l] = function(statement, opts) {
-        opts = opts || {};
+    var levelFuncationName = level.toLowerCase();
+    Logger.prototype[levelFuncationName] = function(statement, opts, callback) {
+        if(opts && typeof opts === 'function') {
+          callback = opts;
+          opts = {};
+        }
+        if(!opts) opts = {};
         opts.level = level;
-        this.log(statement, opts);
+
+        this.log(statement, opts, callback);
     };
 });
 

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -364,7 +364,7 @@ Logger.prototype._flush = function(callback) {
  *  Populate short-hand for each supported Log Level
  */
 configs.LOG_LEVELS.forEach(function(level) {
-    const levelFuncationName = level.toLowerCase();
+    const levelFunctionName = level.toLowerCase();
     Logger.prototype[levelFuncationName] = function(statement, opts, callback) {
         if (opts && typeof opts === 'function') {
             callback = opts;

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -365,7 +365,7 @@ Logger.prototype._flush = function(callback) {
  */
 configs.LOG_LEVELS.forEach(function(level) {
     const levelFunctionName = level.toLowerCase();
-    Logger.prototype[levelFuncationName] = function(statement, opts, callback) {
+    Logger.prototype[levelFunctionName] = function(statement, opts, callback) {
         if (opts && typeof opts === 'function') {
             callback = opts;
             opts = {};

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -364,7 +364,7 @@ Logger.prototype._flush = function(callback) {
  *  Populate short-hand for each supported Log Level
  */
 configs.LOG_LEVELS.forEach(function(level) {
-    let levelFuncationName = level.toLowerCase();
+    const levelFuncationName = level.toLowerCase();
     Logger.prototype[levelFuncationName] = function(statement, opts, callback) {
         if (opts && typeof opts === 'function') {
             callback = opts;

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -364,7 +364,7 @@ Logger.prototype._flush = function(callback) {
  *  Populate short-hand for each supported Log Level
  */
 configs.LOG_LEVELS.forEach(function(level) {
-    var levelFuncationName = level.toLowerCase();
+    let levelFuncationName = level.toLowerCase();
     Logger.prototype[levelFuncationName] = function(statement, opts, callback) {
         if (opts && typeof opts === 'function') {
             callback = opts;

--- a/test/logger.js
+++ b/test/logger.js
@@ -63,18 +63,47 @@ describe('Test all Levels', function() {
         body = '';
         callbackResult = '';
     });
+    describe('passing callback', function() {
+      it('Executes callback when provided - debug', function(done) {
+          allLevelsLogger.debug('Sent a log', testCallback);
+          setTimeout(function() {
+              assert(callbackResult.httpStatus === 200);
+              assert(sentLines[0] === 'Sent a log');
+              assert(sentLevels[0] === 'DEBUG');
+              done();
+          }, configs.FLUSH_INTERVAL + 200);
+      });
+      it('Executes callback when provided - trace', function(done) {
+          allLevelsLogger.trace('Sent a log1', testCallback);
+          setTimeout(function() {
+              assert(callbackResult.httpStatus === 200);
+              assert(sentLines[0] === 'Sent a log1');
+              assert(sentLevels[0] === 'TRACE');
+              done();
+          }, configs.FLUSH_INTERVAL + 200);
+      });
+      it('Executes callback when provided - info', function(done) {
+          allLevelsLogger.info('Sent a log2', testCallback);
+          setTimeout(function() {
+              assert(callbackResult.httpStatus === 200);
+              assert(sentLines[0] === 'Sent a log2');
+              assert(sentLevels[0] === 'INFO');
+              done();
+          }, configs.FLUSH_INTERVAL + 200);
+      });
+      it('Executes callback when provided - warn', function(done) {
+          allLevelsLogger.warn('Sent a log3', testCallback);
+          setTimeout(function() {
+              assert(callbackResult.httpStatus === 200);
+              assert(sentLines[0] === 'Sent a log3');
+              assert(sentLevels[0] === 'WARN');
+              done();
+          }, configs.FLUSH_INTERVAL + 200);
+      });
+     });
     it('Debug Function', function(done) {
         allLevelsLogger.debug('Sent a log');
         setTimeout(function() {
-            assert(sentLines[0] === 'Sent a log');
-            assert(sentLevels[0] === 'DEBUG');
-            done();
-        }, configs.FLUSH_INTERVAL + 200);
-    });
-    it('Debug Functio, when called with callback, should call the cb', function(done) {
-        allLevelsLogger.debug('Sent a log', testCallback);
-        setTimeout(function() {
-            assert(callbackResult.httpStatus === 200);
             assert(sentLines[0] === 'Sent a log');
             assert(sentLevels[0] === 'DEBUG');
             done();
@@ -88,27 +117,9 @@ describe('Test all Levels', function() {
             done();
         }, configs.FLUSH_INTERVAL + 200);
     });
-    it('Trace Function, when called with callback, should call the cb', function(done) {
-        allLevelsLogger.trace('Sent a log1', testCallback);
-        setTimeout(function() {
-            assert(callbackResult.httpStatus === 200);
-            assert(sentLines[0] === 'Sent a log1');
-            assert(sentLevels[0] === 'TRACE');
-            done();
-        }, configs.FLUSH_INTERVAL + 200);
-    });
     it('Info Function', function(done) {
         allLevelsLogger.info('Sent a log2');
         setTimeout(function() {
-            assert(sentLines[0] === 'Sent a log2');
-            assert(sentLevels[0] === 'INFO');
-            done();
-        }, configs.FLUSH_INTERVAL + 200);
-    });
-    it('Info Function, when called with callback, should call the cb', function(done) {
-        allLevelsLogger.info('Sent a log2', testCallback);
-        setTimeout(function() {
-            assert(callbackResult.httpStatus === 200);
             assert(sentLines[0] === 'Sent a log2');
             assert(sentLevels[0] === 'INFO');
             done();
@@ -122,27 +133,9 @@ describe('Test all Levels', function() {
             done();
         }, configs.FLUSH_INTERVAL + 200);
     });
-    it('Warn Function, when called with callback, should call the cb', function(done) {
-        allLevelsLogger.warn('Sent a log3', testCallback);
-        setTimeout(function() {
-            assert(callbackResult.httpStatus === 200);
-            assert(sentLines[0] === 'Sent a log3');
-            assert(sentLevels[0] === 'WARN');
-            done();
-        }, configs.FLUSH_INTERVAL + 200);
-    });
     it('Error Function', function(done) {
         allLevelsLogger.error('Sent a log4');
         setTimeout(function() {
-            assert(sentLines[0] === 'Sent a log4');
-            assert(sentLevels[0] === 'ERROR');
-            done();
-        }, configs.FLUSH_INTERVAL + 200);
-    });
-    it('Error Function, when called with callback, should call the cb', function(done) {
-        allLevelsLogger.error('Sent a log4', testCallback);
-        setTimeout(function() {
-            assert(callbackResult.httpStatus === 200);
             assert(sentLines[0] === 'Sent a log4');
             assert(sentLevels[0] === 'ERROR');
             done();
@@ -156,15 +149,7 @@ describe('Test all Levels', function() {
             done();
         }, configs.FLUSH_INTERVAL + 200);
     });
-    it('Fatal Function, when called with callback, should call the cb', function(done) {
-        allLevelsLogger.fatal('Sent a log5', testCallback);
-        setTimeout(function() {
-            assert(callbackResult.httpStatus === 200);
-            assert(sentLines[0] === 'Sent a log5');
-            assert(sentLevels[0] === 'FATAL');
-            done();
-        }, configs.FLUSH_INTERVAL + 200);
-    });
+
 });
 
 describe('Testing for Correctness', function() {

--- a/test/logger.js
+++ b/test/logger.js
@@ -64,43 +64,43 @@ describe('Test all Levels', function() {
         callbackResult = '';
     });
     describe('passing callback', function() {
-      it('Executes callback when provided - debug', function(done) {
-          allLevelsLogger.debug('Sent a log', testCallback);
-          setTimeout(function() {
-              assert(callbackResult.httpStatus === 200);
-              assert(sentLines[0] === 'Sent a log');
-              assert(sentLevels[0] === 'DEBUG');
-              done();
-          }, configs.FLUSH_INTERVAL + 200);
-      });
-      it('Executes callback when provided - trace', function(done) {
-          allLevelsLogger.trace('Sent a log1', testCallback);
-          setTimeout(function() {
-              assert(callbackResult.httpStatus === 200);
-              assert(sentLines[0] === 'Sent a log1');
-              assert(sentLevels[0] === 'TRACE');
-              done();
-          }, configs.FLUSH_INTERVAL + 200);
-      });
-      it('Executes callback when provided - info', function(done) {
-          allLevelsLogger.info('Sent a log2', testCallback);
-          setTimeout(function() {
-              assert(callbackResult.httpStatus === 200);
-              assert(sentLines[0] === 'Sent a log2');
-              assert(sentLevels[0] === 'INFO');
-              done();
-          }, configs.FLUSH_INTERVAL + 200);
-      });
-      it('Executes callback when provided - warn', function(done) {
-          allLevelsLogger.warn('Sent a log3', testCallback);
-          setTimeout(function() {
-              assert(callbackResult.httpStatus === 200);
-              assert(sentLines[0] === 'Sent a log3');
-              assert(sentLevels[0] === 'WARN');
-              done();
-          }, configs.FLUSH_INTERVAL + 200);
-      });
-     });
+        it('Executes callback when provided - debug', function(done) {
+            allLevelsLogger.debug('Sent a log', testCallback);
+            setTimeout(function() {
+                assert(callbackResult.httpStatus === 200);
+                assert(sentLines[0] === 'Sent a log');
+                assert(sentLevels[0] === 'DEBUG');
+                done();
+            }, configs.FLUSH_INTERVAL + 200);
+        });
+        it('Executes callback when provided - trace', function(done) {
+            allLevelsLogger.trace('Sent a log1', testCallback);
+            setTimeout(function() {
+                assert(callbackResult.httpStatus === 200);
+                assert(sentLines[0] === 'Sent a log1');
+                assert(sentLevels[0] === 'TRACE');
+                done();
+            }, configs.FLUSH_INTERVAL + 200);
+        });
+        it('Executes callback when provided - info', function(done) {
+            allLevelsLogger.info('Sent a log2', testCallback);
+            setTimeout(function() {
+                assert(callbackResult.httpStatus === 200);
+                assert(sentLines[0] === 'Sent a log2');
+                assert(sentLevels[0] === 'INFO');
+                done();
+            }, configs.FLUSH_INTERVAL + 200);
+        });
+        it('Executes callback when provided - warn', function(done) {
+            allLevelsLogger.warn('Sent a log3', testCallback);
+            setTimeout(function() {
+                assert(callbackResult.httpStatus === 200);
+                assert(sentLines[0] === 'Sent a log3');
+                assert(sentLevels[0] === 'WARN');
+                done();
+            }, configs.FLUSH_INTERVAL + 200);
+        });
+    });
     it('Debug Function', function(done) {
         allLevelsLogger.debug('Sent a log');
         setTimeout(function() {

--- a/test/logger.js
+++ b/test/logger.js
@@ -71,7 +71,7 @@ describe('Test all Levels', function() {
             done();
         }, configs.FLUSH_INTERVAL + 200);
     });
-    it('Debug Function with callback', function(done) {
+    it('Debug Functio, when called with callback, should call the cb', function(done) {
         allLevelsLogger.debug('Sent a log', testCallback);
         setTimeout(function() {
             assert(callbackResult.httpStatus === 200);
@@ -88,7 +88,7 @@ describe('Test all Levels', function() {
             done();
         }, configs.FLUSH_INTERVAL + 200);
     });
-    it('Trace Function with callback', function(done) {
+    it('Trace Function, when called with callback, should call the cb', function(done) {
         allLevelsLogger.trace('Sent a log1', testCallback);
         setTimeout(function() {
             assert(callbackResult.httpStatus === 200);
@@ -105,7 +105,7 @@ describe('Test all Levels', function() {
             done();
         }, configs.FLUSH_INTERVAL + 200);
     });
-    it('Info Function with callback', function(done) {
+    it('Info Function, when called with callback, should call the cb', function(done) {
         allLevelsLogger.info('Sent a log2', testCallback);
         setTimeout(function() {
             assert(callbackResult.httpStatus === 200);
@@ -122,7 +122,7 @@ describe('Test all Levels', function() {
             done();
         }, configs.FLUSH_INTERVAL + 200);
     });
-    it('Warn Function with callback', function(done) {
+    it('Warn Function, when called with callback, should call the cb', function(done) {
         allLevelsLogger.warn('Sent a log3', testCallback);
         setTimeout(function() {
             assert(callbackResult.httpStatus === 200);
@@ -139,7 +139,7 @@ describe('Test all Levels', function() {
             done();
         }, configs.FLUSH_INTERVAL + 200);
     });
-    it('Error Function with callback', function(done) {
+    it('Error Function, when called with callback, should call the cb', function(done) {
         allLevelsLogger.error('Sent a log4', testCallback);
         setTimeout(function() {
             assert(callbackResult.httpStatus === 200);
@@ -156,7 +156,7 @@ describe('Test all Levels', function() {
             done();
         }, configs.FLUSH_INTERVAL + 200);
     });
-    it('Fatal Function with callback', function(done) {
+    it('Fatal Function, when called with callback, should call the cb', function(done) {
         allLevelsLogger.fatal('Sent a log5', testCallback);
         setTimeout(function() {
             assert(callbackResult.httpStatus === 200);

--- a/test/logger.js
+++ b/test/logger.js
@@ -31,6 +31,9 @@ describe('Test all Levels', function() {
     let allLevelsServer;
     let sentLines = [];
     let sentLevels = [];
+
+    let callbackResult;
+    const testCallback = (er, res) => { callbackResult = res};
     beforeEach(function(done) {
         allLevelsServer = http.createServer(function(req, res) {
             req.on('data', function(data) {
@@ -58,10 +61,20 @@ describe('Test all Levels', function() {
         sentLines = [];
         sentLevels = [];
         body = '';
+        callbackResult = '';
     });
     it('Debug Function', function(done) {
         allLevelsLogger.debug('Sent a log');
         setTimeout(function() {
+            assert(sentLines[0] === 'Sent a log');
+            assert(sentLevels[0] === 'DEBUG');
+            done();
+        }, configs.FLUSH_INTERVAL + 200);
+    });
+    it('Debug Function with callback', function(done) {
+        allLevelsLogger.debug('Sent a log', testCallback);
+        setTimeout(function() {
+            assert(callbackResult.httpStatus === 200);
             assert(sentLines[0] === 'Sent a log');
             assert(sentLevels[0] === 'DEBUG');
             done();
@@ -75,9 +88,27 @@ describe('Test all Levels', function() {
             done();
         }, configs.FLUSH_INTERVAL + 200);
     });
+    it('Trace Function with callback', function(done) {
+        allLevelsLogger.trace('Sent a log1', testCallback);
+        setTimeout(function() {
+            assert(callbackResult.httpStatus === 200);
+            assert(sentLines[0] === 'Sent a log1');
+            assert(sentLevels[0] === 'TRACE');
+            done();
+        }, configs.FLUSH_INTERVAL + 200);
+    });
     it('Info Function', function(done) {
         allLevelsLogger.info('Sent a log2');
         setTimeout(function() {
+            assert(sentLines[0] === 'Sent a log2');
+            assert(sentLevels[0] === 'INFO');
+            done();
+        }, configs.FLUSH_INTERVAL + 200);
+    });
+    it('Info Function with callback', function(done) {
+        allLevelsLogger.info('Sent a log2', testCallback);
+        setTimeout(function() {
+            assert(callbackResult.httpStatus === 200);
             assert(sentLines[0] === 'Sent a log2');
             assert(sentLevels[0] === 'INFO');
             done();
@@ -91,6 +122,15 @@ describe('Test all Levels', function() {
             done();
         }, configs.FLUSH_INTERVAL + 200);
     });
+    it('Warn Function with callback', function(done) {
+        allLevelsLogger.warn('Sent a log3', testCallback);
+        setTimeout(function() {
+            assert(callbackResult.httpStatus === 200);
+            assert(sentLines[0] === 'Sent a log3');
+            assert(sentLevels[0] === 'WARN');
+            done();
+        }, configs.FLUSH_INTERVAL + 200);
+    });
     it('Error Function', function(done) {
         allLevelsLogger.error('Sent a log4');
         setTimeout(function() {
@@ -99,9 +139,27 @@ describe('Test all Levels', function() {
             done();
         }, configs.FLUSH_INTERVAL + 200);
     });
+    it('Error Function with callback', function(done) {
+        allLevelsLogger.error('Sent a log4', testCallback);
+        setTimeout(function() {
+            assert(callbackResult.httpStatus === 200);
+            assert(sentLines[0] === 'Sent a log4');
+            assert(sentLevels[0] === 'ERROR');
+            done();
+        }, configs.FLUSH_INTERVAL + 200);
+    });
     it('Fatal Function', function(done) {
         allLevelsLogger.fatal('Sent a log5');
         setTimeout(function() {
+            assert(sentLines[0] === 'Sent a log5');
+            assert(sentLevels[0] === 'FATAL');
+            done();
+        }, configs.FLUSH_INTERVAL + 200);
+    });
+    it('Fatal Function with callback', function(done) {
+        allLevelsLogger.fatal('Sent a log5', testCallback);
+        setTimeout(function() {
+            assert(callbackResult.httpStatus === 200);
             assert(sentLines[0] === 'Sent a log5');
             assert(sentLevels[0] === 'FATAL');
             done();
@@ -596,6 +654,17 @@ describe('HTTP Exception Handling', function() {
 
         setTimeout(function() {
             assert(errMes.includes('status code:'));
+            done();
+        }, configs.FLUSH_INTERVAL + 200);
+    });
+    it('if log has a callback, it should be called with an error', function(done) {
+        const opts = testHelper.createOptions({port: port});
+        const flushAllTest = Logger.createLogger(testHelper.apikey, opts);
+        let callbackError;
+        flushAllTest.log("Test line", (e) => {callbackError = e});
+
+        setTimeout(function() {
+            assert(callbackError === 'An error occured while making the request. Response status code: 302 Found');
             done();
         }, configs.FLUSH_INTERVAL + 200);
     });

--- a/test/logger.js
+++ b/test/logger.js
@@ -33,7 +33,7 @@ describe('Test all Levels', function() {
     let sentLevels = [];
 
     let callbackResult;
-    const testCallback = (er, res) => { callbackResult = res;};
+    const testCallback = (er, res) => { callbackResult = res; };
     beforeEach(function(done) {
         allLevelsServer = http.createServer(function(req, res) {
             req.on('data', function(data) {

--- a/test/logger.js
+++ b/test/logger.js
@@ -33,7 +33,7 @@ describe('Test all Levels', function() {
     let sentLevels = [];
 
     let callbackResult;
-    const testCallback = (er, res) => { callbackResult = res};
+    const testCallback = (er, res) => { callbackResult = res;};
     beforeEach(function(done) {
         allLevelsServer = http.createServer(function(req, res) {
             req.on('data', function(data) {
@@ -661,7 +661,7 @@ describe('HTTP Exception Handling', function() {
         const opts = testHelper.createOptions({port: port});
         const flushAllTest = Logger.createLogger(testHelper.apikey, opts);
         let callbackError;
-        flushAllTest.log("Test line", (e) => {callbackError = e});
+        flushAllTest.log('Test line', (e) => {callbackError = e;});
 
         setTimeout(function() {
             assert(callbackError === 'An error occured while making the request. Response status code: 302 Found');


### PR DESCRIPTION
Adds an option to pass a callback when the log (or any other logging function) is called. It will pass the object with the response code and the response or an error to the callback after sending the request to the server. 