### PR TITLE
Fixes callback being called immediately after `flushAll`

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -372,19 +372,32 @@ const flushAll = function(cb) {
     if (!cb || typeof cb !== 'function') {
         cb = debug;
     }
+
+    // Variables used to wait for all the flushes to be completed
+    const counter = 0;
+    const loggersCount = loggers.length;    
+    const complete = (errors) => {
+        if (errors.length > 0) {
+            return cb(`The following errors happened while flushing all loggers: ${errors}`);
+        } else {
+            return cb();
+        }
+    }
+    
     const errors = [];
     loggers.forEach((logger) => {
         logger._flush((err) => {
             if (err) {
                 errors.push(err);
             }
+            // Counter is incremented after each flush
+            if (++counter === loggersCount) {
+                // Flushed all the loggers
+                // Completes by calling the callback
+                complete(errors);
+            }
         });
     });
-
-    if (errors.length > 0) {
-        return cb(`The following errors happened while flushing all loggers: ${errors}`);
-    }
-    return cb();
 };
 
 exports.Logger = Logger;

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -384,19 +384,32 @@ const flushAll = function(cb) {
     if (!cb || typeof cb !== 'function') {
         cb = debug;
     }
+
+    // Variables used to wait for all the flushes to be completed
+    const counter = 0;
+    const loggersCount = loggers.length;    
+    const complete = (errors) => {
+        if (errors.length > 0) {
+            return cb(`The following errors happened while flushing all loggers: ${errors}`);
+        } else {
+            return cb();
+        }
+    }
+    
     const errors = [];
     loggers.forEach((logger) => {
         logger._flush((err) => {
             if (err) {
                 errors.push(err);
             }
+            // Counter is incremented after each flush
+            if (++counter === loggersCount) {
+                // Flushed all the loggers
+                // Completes by calling the callback
+                complete(errors);
+            }
         });
     });
-
-    if (errors.length > 0) {
-        return cb(`The following errors happened while flushing all loggers: ${errors}`);
-    }
-    return cb();
 };
 
 exports.Logger = Logger;

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -387,15 +387,15 @@ const flushAll = function(cb) {
 
     // Variables used to wait for all the flushes to be completed
     let counter = 0;
-    const loggersCount = loggers.length;    
+    const loggersCount = loggers.length;
     const complete = (errors) => {
         if (errors.length > 0) {
             return cb(`The following errors happened while flushing all loggers: ${errors}`);
-        } else {
-            return cb();
         }
-    }
-    
+        return cb();
+
+    };
+
     const errors = [];
     loggers.forEach((logger) => {
         logger._flush((err) => {
@@ -404,8 +404,11 @@ const flushAll = function(cb) {
             }
             // Counter is incremented after each flush
             if (++counter === loggersCount) {
-                // Flushed all the loggers
-                // Completes by calling the callback
+
+                /*
+                 * Flushed all the loggers
+                 * Completes by calling the callback
+                 */
                 complete(errors);
             }
         });

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -386,7 +386,7 @@ const flushAll = function(cb) {
     }
 
     // Variables used to wait for all the flushes to be completed
-    const counter = 0;
+    let counter = 0;
     const loggersCount = loggers.length;    
     const complete = (errors) => {
         if (errors.length > 0) {

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -374,7 +374,7 @@ const flushAll = function(cb) {
     }
 
     // Variables used to wait for all the flushes to be completed
-    const counter = 0;
+    let counter = 0;
     const loggersCount = loggers.length;    
     const complete = (errors) => {
         if (errors.length > 0) {

--- a/test/logger.js
+++ b/test/logger.js
@@ -288,9 +288,6 @@ describe('Index meta', function() {
 });
 
 describe('Input validation', function() {
-    afterEach(function(done) {
-        Logger.flushAll(done);
-    });
     it('Sanity checks for Ingestion Key', function(done) {
         const bogusKeys = [
             'THIS KEY IS TOO LONG THIS KEY IS TOO LONG THIS KEY IS TOO LONG THIS KEY IS TOO LONG THIS KEY IS TOO LONG THIS KEY IS TOO LONG'
@@ -435,10 +432,6 @@ describe('Multiple loggers', function() {
 describe('ambient meta', function() {
     const options = testHelper.createOptions();
     const ambientLogger = Logger.createLogger(testHelper.apikey, options);
-
-    beforeEach(function() {
-        Logger.flushAll();
-    });
 
     it('add string ambient meta to a string log line', function() {
         ambientLogger.addMetaProperty('ambient', 'someAmbientMeta');

--- a/test/logger.js
+++ b/test/logger.js
@@ -433,6 +433,10 @@ describe('ambient meta', function() {
     const options = testHelper.createOptions();
     const ambientLogger = Logger.createLogger(testHelper.apikey, options);
 
+    beforeEach(function() {
+        Logger.flushAll();
+    });
+
     it('add string ambient meta to a string log line', function() {
         ambientLogger.addMetaProperty('ambient', 'someAmbientMeta');
         ambientLogger.log('Sent a string log');


### PR DESCRIPTION
`flushAll` callback is called immediately, and it doesn't wait for all the flushes to be completed. This commit waits for all the flush callbacks to be completed and then completes the final callback.