### PR TITLE
Check if opts has saveServiceCopy property - not if it is truthy

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -207,15 +207,15 @@ Logger.prototype.log = function(statement, opts) {
             }
 
             if (opts.logSourceCRN) {
-              message.logSourceCRN = opts.logSourceCRN
+                message.logSourceCRN = opts.logSourceCRN;
             }
 
             if (opts.saveServiceCopy) {
-              message.saveServiceCopy = opts.saveServiceCopy
+                message.saveServiceCopy = opts.saveServiceCopy;
             }
 
             if (opts.appOverride) {
-              message.appOverride = opts.appOverride
+                message.appOverride = opts.appOverride;
             }
         }
     } else if (!this._index_meta) {

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -208,15 +208,19 @@ Logger.prototype.log = function(statement, opts) {
                 }
             }
 
-            if (opts.logSourceCRN) {
+            if (opts.hasOwnProperty('logSourceCRN')) {
                 message.logSourceCRN = opts.logSourceCRN;
             }
 
             if (opts.hasOwnProperty('saveServiceCopy')) {
+                if (typeof opts.saveServiceCopy !== 'boolean') {
+                    this._err = true;
+                    debug('Can only pass a Boolean for saveServiceCopy property');
+                }
                 message.saveServiceCopy = opts.saveServiceCopy;
             }
 
-            if (opts.appOverride) {
+            if (opts.hasOwnProperty('appOverride')) {
                 message.appOverride = opts.appOverride;
             }
         }

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -212,7 +212,7 @@ Logger.prototype.log = function(statement, opts) {
                 message.logSourceCRN = opts.logSourceCRN;
             }
 
-            if (opts.saveServiceCopy) {
+            if (opts.hasOwnProperty('saveServiceCopy')) {
                 message.saveServiceCopy = opts.saveServiceCopy;
             }
 

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -205,6 +205,18 @@ Logger.prototype.log = function(statement, opts) {
                     message.meta = stringify(opts.meta);
                 }
             }
+
+            if (opts.logSourceCRN) {
+              message.logSourceCRN = opts.logSourceCRN
+            }
+
+            if (opts.saveServiceCopy) {
+              message.saveServiceCopy = opts.saveServiceCopy
+            }
+
+            if (opts.appOverride) {
+              message.appOverride = opts.appOverride
+            }
         }
     } else if (!this._index_meta) {
         message.meta = stringify(message.meta);


### PR DESCRIPTION
Previous code was only checking if the `opts.saveServiceCopy` property was truthy:
```
if (opts.saveServiceCopy) {
    message.saveServiceCopy = opts.saveServiceCopy;
}
```

When `saveServiceCopy` was `true` it would set it on the message object, however, when `saveServiceCopy` was `false` the if statement evaluated false and the property was not set on the message object.

This PR changes the check so that it checks if there is a `saveServiceCopy` property on the `opts` object, and if there is then it sets it - rather than checking if the value of the property is truthy.