### PR TITLE
docs: remove 'shimProperties' from doc and add to CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,25 @@
 This file documents all notable changes in `LogDNA Node.js Code Library`. The release numbering uses [semantic versioning](http://semver.org).
 
 ## Next Release [MAJOR]
-- Breaking Change: Add support for custom properties by adding `shimProperties` option when creating an logger. In order to continue to see fields `appOverride`, `logSourceCRN`, and `saveServiceCopy` in the message, need to add those properties in `shimProperties`.
+- Breaking Change: Add support for custom properties by adding `shimProperties` option when creating an logger. In order to continue to see fields `appOverride`, `logSourceCRN`, and `saveServiceCopy` in the message, need to add those properties in `shimProperties` like the following:
+```javascript
+const Logger = require('logdna');
+const options = {
+    hostname: myHostname,
+    ip: ipAddress,
+    mac: macAddress,
+    app: appName,
+    env: envName,
+    shimProperties: ['appOverride', 'logSourceCRN', 'saveServiceCopy']
+};
+const logger = Logger.createLogger(apikey, options);
+
+logger.log('My Sample Log Line', {
+    appOverride: true,
+    logSourceCRN: 'good',
+    saveServiceCopy: false
+});
+```
 
 ## v3.3.3 - September 20, 2019
 - Add User Agent to the Request Header

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 This file documents all notable changes in `LogDNA Node.js Code Library`. The release numbering uses [semantic versioning](http://semver.org).
 
 ## Next Release [MAJOR]
-- Breaking Change: Add support for custom properties by adding `shimProperties` option when creating an logger. In order to continue to see fields `appOverride`, `logSourceCRN`, and `saveServiceCopy` in the message, need to add those properties in `shimProperties` like the following:
+- Breaking Change: Add support for custom properties via the `shimProperties` option when creating an logger. To continue to see the fields `appOverride`, `logSourceCRN`, and `saveServiceCopy` in the message, they must be specified in `shimProperties`:
 ```javascript
 const Logger = require('logdna');
 const options = {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,27 +2,6 @@
 
 This file documents all notable changes in `LogDNA Node.js Code Library`. The release numbering uses [semantic versioning](http://semver.org).
 
-## Next Release [MAJOR]
-- Breaking Change: Add support for custom properties via the `shimProperties` option when creating an logger. To continue to see the fields `appOverride`, `logSourceCRN`, and `saveServiceCopy` in the message, they must be specified in `shimProperties`:
-```javascript
-const Logger = require('logdna');
-const options = {
-    hostname: myHostname,
-    ip: ipAddress,
-    mac: macAddress,
-    app: appName,
-    env: envName,
-    shimProperties: ['appOverride', 'logSourceCRN', 'saveServiceCopy']
-};
-const logger = Logger.createLogger(apikey, options);
-
-logger.log('My Sample Log Line', {
-    appOverride: true,
-    logSourceCRN: 'good',
-    saveServiceCopy: false
-});
-```
-
 ## v3.3.3 - September 20, 2019
 - Add User Agent to the Request Header
 

--- a/README.md
+++ b/README.md
@@ -44,9 +44,6 @@ options.tags = ['logging', 'nodejs', 'logdna'];
 // or:
 options.tags = 'logging,nodejs,logdna';
 
-// Customized options that will be applied to message during `.log` call
-options.shimProperties = ['prop1', 'prop2', 'prop3'];
-
 // Create multiple loggers with different options
 var logger = Logger.createLogger(apikey, options);
 
@@ -130,27 +127,6 @@ logger.log('My Sample Log Line', opts);
 
 ```
 You will see the outputs in your LogDNA dashboard.
-
-If customized options is needed in the message, `shimProperties` can be used:
-```javascript
-const Logger = require('logdna');
-const options = {
-    hostname: myHostname,
-    ip: ipAddress,
-    mac: macAddress,
-    app: appName,
-    env: envName,
-    shimProperties: ['prop1', 'prop2', 'prop3']
-};
-const logger = Logger.createLogger(apikey, options);
-
-logger.log('My Sample Log Line', {
-    prop1: true,
-    prop2: 'good',
-    prop4: false
-});
-```
-You will see `prop1` and `prop2` be logged, but neither of `prop3` and `prop4` are logged.
 
 ## API
 


### PR DESCRIPTION
Since this `shimProperties` is not widely used and won't make any impact on LogDNA web, we don't need to put it in README.md. 