### PR TITLE
Only set user-agent header in Node

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -145,7 +145,7 @@ function Logger(key, options) {
     this._req = {
         auth: { username: key }
         , agent: useHttps ? new Agent.HttpsAgent(configs.AGENT_SETTING) : new Agent(configs.AGENT_SETTING)
-        , headers: Object.assign({}, clone(configs.DEFAULT_REQUEST_HEADER), {
+        , headers: Object.assign({}, clone(configs.DEFAULT_REQUEST_HEADER), typeof window === 'undefined' && {
             'user-agent': options.UserAgent || configs.DEFAULT_USER_AGENT
         })
         , qs: {


### PR DESCRIPTION
Fixes #86 

This avoids setting the `user-agent` header altogether, which should be ok per spec but currently emits a logged error in Safari and Chrome (see issue) so the fix avoids setting the header altogether in the browser since that is a large chunk of the browser market share, thoughts on this?