### PR TITLE
Add browser detection

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -184,6 +184,7 @@
         "no-process-env": "off",
         "no-process-exit": "error",
         "no-proto": "error",
+        "no-prototype-builtins": "off",
         "no-restricted-globals": "error",
         "no-restricted-imports": "error",
         "no-restricted-modules": "error",

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -145,14 +145,14 @@ function Logger(key, options) {
 
     if (typeof window === 'object') {
         headers = {
-          ...configs.DEFAULT_REQUEST_HEADER
-          , 'source': `browser/${pkg.version}`
-        }
+            ...configs.DEFAULT_REQUEST_HEADER
+            , 'source': `browser/${pkg.version}`
+        };
     } else {
         headers = {
-          ...configs.DEFAULT_REQUEST_HEADER
-          , 'user-agent': options.UserAgent || configs.DEFAULT_USER_AGENT
-        }
+            ...configs.DEFAULT_REQUEST_HEADER
+            , 'user-agent': options.UserAgent || configs.DEFAULT_USER_AGENT
+        };
     }
 
     this._req = {

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -144,11 +144,15 @@ function Logger(key, options) {
     let headers;
 
     if (typeof window === 'object') {
-        headers = Object.assign(configs.DEFAULT_REQUEST_HEADER, {'source': `browser/${pkg.version}`});
+        headers = {
+          ...configs.DEFAULT_REQUEST_HEADER
+          , 'source': `browser/${pkg.version}`
+        }
     } else {
-        headers = Object.assign(configs.DEFAULT_REQUEST_HEADER, {
-            'user-agent': options.UserAgent || configs.DEFAULT_USER_AGENT
-        });
+        headers = {
+          ...configs.DEFAULT_REQUEST_HEADER
+          , 'user-agent': options.UserAgent || configs.DEFAULT_USER_AGENT
+        }
     }
 
     this._req = {

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -154,7 +154,7 @@ function Logger(key, options) {
     this._req = {
         auth: { username: key }
         , agent: useHttps ? new Agent.HttpsAgent(configs.AGENT_SETTING) : new Agent(configs.AGENT_SETTING)
-        , headers: headers
+        , headers
         , qs: {
             hostname: this.source.hostname
             , mac: options.mac || undefined

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -14,7 +14,7 @@ const os = require('os');
 const sizeof = require('object-sizeof');
 const stringify = require('json-stringify-safe');
 const validUrl = require('valid-url');
-const { detect } = require('detect-browser');
+const pkg = require('../package.json');
 
 // Configuration
 const configs = require('./configs');
@@ -144,8 +144,7 @@ function Logger(key, options) {
     let headers;
 
     if (typeof window === 'object') {
-        const browser = detect().name.split(' ').join('');
-        headers = Object.assign(configs.DEFAULT_REQUEST_HEADER, {'source': `browser/${browser}`});
+        headers = Object.assign(configs.DEFAULT_REQUEST_HEADER, {'source': `browser/${pkg.version}`});
     } else {
         headers = Object.assign(configs.DEFAULT_REQUEST_HEADER, {
             'user-agent': options.UserAgent || configs.DEFAULT_USER_AGENT

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -8,13 +8,13 @@
 // External Modules
 const Agent = require('agentkeepalive');
 const axios = require('axios');
-const clone = require('lodash.clonedeep');
 const debug = require('util').debuglog('logdna');
 const querystring = require('querystring');
 const os = require('os');
 const sizeof = require('object-sizeof');
 const stringify = require('json-stringify-safe');
 const validUrl = require('valid-url');
+const { detect } = require('detect-browser');
 
 // Configuration
 const configs = require('./configs');
@@ -141,13 +141,21 @@ function Logger(key, options) {
     };
 
     const useHttps = configs.AGENT_PROTOCOL === 'https';
+    let headers;
+
+    if (typeof window === 'object') {
+        const browser = detect().name.split(' ').join('');
+        headers = Object.assign(configs.DEFAULT_REQUEST_HEADER, {'source': `browser/${browser}`});
+    } else {
+        headers = Object.assign(configs.DEFAULT_REQUEST_HEADER, {
+            'user-agent': options.UserAgent || configs.DEFAULT_USER_AGENT
+        });
+    }
 
     this._req = {
         auth: { username: key }
         , agent: useHttps ? new Agent.HttpsAgent(configs.AGENT_SETTING) : new Agent(configs.AGENT_SETTING)
-        , headers: Object.assign({}, clone(configs.DEFAULT_REQUEST_HEADER), typeof window === 'undefined' && {
-            'user-agent': options.UserAgent || configs.DEFAULT_USER_AGENT
-        })
+        , headers: headers
         , qs: {
             hostname: this.source.hostname
             , mac: options.mac || undefined
@@ -159,7 +167,6 @@ function Logger(key, options) {
         , useHttps: useHttps
     };
     this._req.headers.Authorization = 'Basic ' + Buffer.from(`${key}:`).toString('base64');
-
     loggers.push(this);
 }
 

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -15,8 +15,9 @@ const sizeof = require('object-sizeof');
 const stringify = require('json-stringify-safe');
 const validUrl = require('valid-url');
 const pkg = require('../package.json');
+const browser = require('detect-browser').detect();
 
-// Configuration
+//Configuration
 const configs = require('./configs');
 
 // Variables
@@ -146,7 +147,7 @@ function Logger(key, options) {
     if (typeof window === 'object') {
         headers = {
             ...configs.DEFAULT_REQUEST_HEADER
-            , 'source': `browser/${pkg.version}`
+            , 'source': `${options.UserAgent}/${pkg.version} (${browser.name}/${browser.version})`
         };
     } else {
         headers = {

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -142,19 +142,14 @@ function Logger(key, options) {
     };
 
     const useHttps = configs.AGENT_PROTOCOL === 'https';
-    let headers;
 
-    if (typeof window === 'object') {
-        headers = {
+    const headers = (typeof window === 'object') ? {
             ...configs.DEFAULT_REQUEST_HEADER
-            , 'source': `${options.UserAgent}/${pkg.version} (${browser.name}/${browser.version})`
-        };
-    } else {
-        headers = {
+            , source: `${options.UserAgent}/${pkg.version} (${browser.name}/${browser.version})`
+        } : {
             ...configs.DEFAULT_REQUEST_HEADER
             , 'user-agent': options.UserAgent || configs.DEFAULT_USER_AGENT
         };
-    }
 
     this._req = {
         auth: { username: key }

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -17,7 +17,7 @@ const validUrl = require('valid-url');
 const pkg = require('../package.json');
 const browser = require('detect-browser').detect();
 
-//Configuration
+// Configuration
 const configs = require('./configs');
 
 // Variables
@@ -144,12 +144,12 @@ function Logger(key, options) {
     const useHttps = configs.AGENT_PROTOCOL === 'https';
 
     const headers = (typeof window === 'object') ? {
-            ...configs.DEFAULT_REQUEST_HEADER
-            , source: `${options.UserAgent}/${pkg.version} (${browser.name}/${browser.version})`
-        } : {
-            ...configs.DEFAULT_REQUEST_HEADER
-            , 'user-agent': options.UserAgent || configs.DEFAULT_USER_AGENT
-        };
+        ...configs.DEFAULT_REQUEST_HEADER
+        , source: `${options.UserAgent}/${pkg.version} (${browser.name}/${browser.version})`
+    } : {
+        ...configs.DEFAULT_REQUEST_HEADER
+        , 'user-agent': options.UserAgent || configs.DEFAULT_USER_AGENT
+    };
 
     this._req = {
         auth: { username: key }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
   "dependencies": {
     "agentkeepalive": "^2.2.0",
     "axios": "^0.19.0",
-    "detect-browser": "^4.8.0",
     "es6-promise": "^4.2.6",
     "json-stringify-safe": "^5.0.1",
     "lodash.bind": "^4.2.1",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
   "dependencies": {
     "agentkeepalive": "^2.2.0",
     "axios": "^0.19.0",
-    "bowser": "^2.7.0",
     "detect-browser": "^4.8.0",
     "es6-promise": "^4.2.6",
     "json-stringify-safe": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,8 @@
   "dependencies": {
     "agentkeepalive": "^2.2.0",
     "axios": "^0.19.0",
+    "bowser": "^2.7.0",
+    "detect-browser": "^4.8.0",
     "es6-promise": "^4.2.6",
     "json-stringify-safe": "^5.0.1",
     "lodash.bind": "^4.2.1",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "dependencies": {
     "agentkeepalive": "^2.2.0",
     "axios": "^0.19.0",
+    "detect-browser": "^4.8.0",
     "es6-promise": "^4.2.6",
     "json-stringify-safe": "^5.0.1",
     "lodash.bind": "^4.2.1",


### PR DESCRIPTION
Setting the user-agent header pollutes browsers' console. I set 'source' header instead of 'user-agent' to the request header. This header does not trigger the same error message in the browser console. 
Add the browser detection library to get the information about browser. @andkon wants to have this info.