### PR TITLE
Flush automatically after Backoff timer

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,7 +436,10 @@ exports.handler = (event, context, callback) => {
 ```
 
 ## HTTP Exception Handling
-If the logger does not receive a successful response from the server, it retains the logs in a buffer and will retry with the next request. The size of the retry buffer that saves logs that failed to send and the retry timeout are configurable via:
+If the logger does not receive a successful response from the server, it retains the logs in a buffer and will retry
+after the Backoff Period. If the buffer is full it will immediately try and flush, and will not accept further logs
+until the flush succeeds. The size of the retry buffer that saves logs that failed to send and the retry timeout are
+configurable via:
 
 ``` javascript
 var options = {

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -108,7 +108,7 @@ function Logger(key, options) {
     }
 
     if (options.retryTimeout && Number.isInteger(options.retryTimeout)) {
-        this._retryTimeout = options._retryTimeout;
+        this._retryTimeout = options.retryTimeout;
     } else {
         this._retryTimeout = configs.BACKOFF_PERIOD;
     }
@@ -281,11 +281,7 @@ Logger.prototype._bufferLog = function(message, callback) {
     }
 
     if (this._isLoggingBackedOff) {
-        debug('Backing off.');
-        this._isLoggingBackedOff = false;
-        this._flusher = setTimeout(() => {
-            this._flush(callback);
-        }, this._retryTimeout);
+        debug('Logging is currently backed off. Waiting for timer.');
     }
 
     if (!this._flusher) {
@@ -322,7 +318,20 @@ Logger.prototype._sendRequest = function(config, instance) {
             return instance.callback(`Unsuccessful request. Status text: ${response ? response.statusText : ''}`);
         })
         .catch((err) => {
-            if (err.response) instance._isLoggingBackedOff = true;
+            if (err.response) {
+                instance._isLoggingBackedOff = true;
+                debug('Flush failed. Backing off.');
+                if (!instance._flusher) {
+                    debug('Setting a backoff timer');
+                    instance._flusher = setTimeout(() => {
+                        instance._flush((err) => {
+                            if (err) {
+                                debug('Received an error while flushing...' + err);
+                            }
+                        });
+                    }, instance._retryTimeout);
+                }
+            }
             // Return to buffer
             instance._buf = JSON.parse(config.data).ls;
             instance._bufByteLength = instance.__bufSizePreserve;
@@ -344,6 +353,7 @@ Logger.prototype._flush = function(callback) {
         return callback();
     }
 
+    debug('Clearing the timer');
     clearTimeout(this._flusher);
     this._flusher = null;
 


### PR DESCRIPTION
On a quiet microservice log lines can be held in buffer for hours or days after a temporary network problem is restored. This can interfere greatly when trying to diagnose an application problem through logs that are expected to be in LogDNA, but are instead buffered waiting to be sent.

This PR changes the behaviour to use a setTimeout for backoff interval when a flush has failed, rather than on the submission of a new message to the buffer. This allows the flush to happen reasonably quickly after a network problem has resolved.

In addition we fix the loading of the `retryTimeout` option into `this._ retryTimeout`.

In addition to adding new tests to cover this, there's also some test cleanup that we found helped us to understand the flow of the HTTP Exception test cases - the use of two separate flags `edgeCaseFlag` and `countHits` for what were only ever used to do the job of a boolean, for example.