### PR TITLE
Try to flush after failing without waiting for the next log.

### DIFF
--- a/lib/configs.js
+++ b/lib/configs.js
@@ -21,4 +21,5 @@ module.exports = {
     , REQUEST_WITH_CREDENTIALS: false
     , BACKOFF_PERIOD: 3000
     , FAILED_BUF_RETENTION_LIMIT: 10000000
+    , RETRY_TIMES: 3
 };

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -334,7 +334,6 @@ Logger.prototype._sendRequest = function(config, instance) {
             // Return to buffer
             instance._buf = instance._buf.concat(JSON.parse(config.data).ls);
             instance._bufByteLength += instance.__bufSizePreserve;
-
             if(!instance._flusher && instance._attempts < instance._retryTimes) {
                 instance._attempts += 1;
                 instance._flusher = setTimeout(() => {

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -101,6 +101,12 @@ function Logger(key, options) {
         this._flushLimit = configs.FLUSH_BYTE_LIMIT;
     }
 
+    if (options.retryTimes && Number.isInteger(options.retryTimes)) {
+        this._retryTimes = options.retryTimes;
+    } else {
+        this._retryTimes = configs.RETRY_TIMES;
+    }
+
     if (options.flushInterval && Number.isInteger(options.flushInterval)) {
         this._flushInterval = options.flushInterval;
     } else {
@@ -108,7 +114,7 @@ function Logger(key, options) {
     }
 
     if (options.retryTimeout && Number.isInteger(options.retryTimeout)) {
-        this._retryTimeout = options._retryTimeout;
+        this._retryTimeout = options.retryTimeout;
     } else {
         this._retryTimeout = configs.BACKOFF_PERIOD;
     }
@@ -131,6 +137,7 @@ function Logger(key, options) {
     this._buf = [];
     this._meta = {};
     this._isLoggingBackedOff = false;
+    this._attempts = 0;
 
     this.source = {
         hostname: options.hostname || os.hostname()
@@ -273,6 +280,7 @@ Logger.prototype._bufferLog = function(message, callback) {
 
     if (!this._isLoggingBackedOff && (this._bufByteLength >= this._flushLimit)) {
         debug('Buffer size meets (or exceeds) flush limit.  Immediately flushing');
+
         this._flush((err) => {
             if (err) {
                 debug('Received an error while flushing...' + err);
@@ -290,6 +298,7 @@ Logger.prototype._bufferLog = function(message, callback) {
 
     if (!this._flusher) {
         debug('No scheduled flush. Scheduling for %d ms from now.', configs.FLUSH_INTERVAL);
+
         this._flusher = setTimeout(() => {
             this._flush(callback);
         }, this._flushInterval);
@@ -313,6 +322,7 @@ Logger.prototype._sendRequest = function(config, instance) {
         .then((response) => {
             if (response && response.status === 200) {
                 instance._isLoggingBackedOff = false;
+                instance._attempts = 0;
                 return instance.callback(null, {
                     lines: instance.__dbgLines
                     , httpStatus: response.status
@@ -324,8 +334,15 @@ Logger.prototype._sendRequest = function(config, instance) {
         .catch((err) => {
             if (err.response) instance._isLoggingBackedOff = true;
             // Return to buffer
-            instance._buf = JSON.parse(config.data).ls;
-            instance._bufByteLength = instance.__bufSizePreserve;
+            instance._buf = instance._buf.concat(JSON.parse(config.data).ls);
+            instance._bufByteLength += instance.__bufSizePreserve;
+
+            if(!instance._flusher && instance._attempts < instance._retryTimes) {
+                instance._attempts += 1;
+                instance._flusher = setTimeout(() => {
+                  instance._flush(instance.callback)
+                }, instance._retryTimeout);
+            }
 
             let message = 'An error occured while making the request.';
             if (err && err.response) {
@@ -339,13 +356,14 @@ Logger.prototype._flush = function(callback) {
     if (!callback || typeof callback !== 'function') {
         throw new Error('flush function expects a callback');
     }
+
+    clearTimeout(this._flusher);
+    this._flusher = null;
+
     if (this._buf.length === 0) {
         debug('Nothing to flush');
         return callback();
     }
-
-    clearTimeout(this._flusher);
-    this._flusher = null;
 
     const data = stringify({ e: 'ls', ls: this._buf });
     this._req.qs.now = Date.now();
@@ -373,7 +391,6 @@ Logger.prototype._flush = function(callback) {
 
     this._sendRequest(_config, this);
 };
-
 
 /*
  *  Populate short-hand for each supported Log Level

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -280,7 +280,6 @@ Logger.prototype._bufferLog = function(message, callback) {
 
     if (!this._isLoggingBackedOff && (this._bufByteLength >= this._flushLimit)) {
         debug('Buffer size meets (or exceeds) flush limit.  Immediately flushing');
-
         this._flush((err) => {
             if (err) {
                 debug('Received an error while flushing...' + err);
@@ -298,7 +297,6 @@ Logger.prototype._bufferLog = function(message, callback) {
 
     if (!this._flusher) {
         debug('No scheduled flush. Scheduling for %d ms from now.', configs.FLUSH_INTERVAL);
-
         this._flusher = setTimeout(() => {
             this._flush(callback);
         }, this._flushInterval);

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -334,10 +334,10 @@ Logger.prototype._sendRequest = function(config, instance) {
             // Return to buffer
             instance._buf = instance._buf.concat(JSON.parse(config.data).ls);
             instance._bufByteLength += instance.__bufSizePreserve;
-            if(!instance._flusher && instance._attempts < instance._retryTimes) {
+            if (!instance._flusher && instance._attempts < instance._retryTimes) {
                 instance._attempts += 1;
                 instance._flusher = setTimeout(() => {
-                  instance._flush(instance.callback)
+                    instance._flush(instance.callback);
                 }, instance._retryTimeout);
             }
 

--- a/test/logger.js
+++ b/test/logger.js
@@ -538,9 +538,11 @@ describe('HTTP Exception Handling', function() {
 
     const port = 1336;
     const retryTimeout = 500;
+    const retryTimes = 2
     const options = testHelper.createOptions({
         port: port
-        , retryTimeout: retryTimeout
+        , retryTimeout
+        , retryTimes
 
     });
 
@@ -585,18 +587,18 @@ describe('HTTP Exception Handling', function() {
             done();
         }, retryTimeout * 3 + 200);
     });
-    it('when fails to connect, it should retry only three times and save the log until the next one comes in', function(done) {
-        this.timeout(retryTimeout * 3 + 400);
+    it('when fails to connect, it should retry only options.retryTimes and save the log until the next one comes in', function(done) {
+        this.timeout(retryTimeout * 4 + 400);
         let logSentTime = Date.now();
         httpExcLogger.debug('The line');
 
         setTimeout(function() {
-            assert(countServertHits === 3);
+            assert(countServertHits === retryTimes + 1);
             assert(httpExcLogger._buf.length === 1);
             done();
-        }, retryTimeout * 3 + 200);
+        }, retryTimeout * 4);
     });
-    it('*!!depends on the previous test!!* Include the log from the previously faliled flush', function(done) {
+    it('*!!depends on the previous test!!* Include the log from the previously failed flush', function(done) {
         this.timeout(retryTimeout + 300);
         willEventuallySucceed = true;
         countServertHits = 1;

--- a/test/logger.js
+++ b/test/logger.js
@@ -538,7 +538,7 @@ describe('HTTP Exception Handling', function() {
 
     const port = 1336;
     const retryTimeout = 500;
-    const retryTimes = 2
+    const retryTimes = 2;
     const options = testHelper.createOptions({
         port: port
         , retryTimeout
@@ -579,7 +579,7 @@ describe('HTTP Exception Handling', function() {
     it('when fails to connect, it should retry within retryTimeout period', function(done) {
         this.timeout(retryTimeout * 3 + 400);
         willEventuallySucceed = true;
-        let logSentTime = Date.now();
+        const logSentTime = Date.now();
         httpExcLogger.debug('The line');
         setTimeout(function() {
             assert(whenSuccessConnection - logSentTime >= retryTimeout);
@@ -589,7 +589,6 @@ describe('HTTP Exception Handling', function() {
     });
     it('when fails to connect, it should retry only options.retryTimes and save the log until the next one comes in', function(done) {
         this.timeout(retryTimeout * 4 + 400);
-        let logSentTime = Date.now();
         httpExcLogger.debug('The line');
 
         setTimeout(function() {

--- a/test/logger.js
+++ b/test/logger.js
@@ -609,7 +609,7 @@ describe('HTTP Exception Handling', function() {
             done();
         }, retryTimeout + 200);
     });
-    it('*!!depends on the previous test!!* Should clear backoff after success', function(done) {
+    it('*!!depends on the previous test!!* Should clear backoff after success and nullify attempts', function(done) {
         this.timeout(3500);
         willEventuallySucceed = true;
         countServertHits = 1;
@@ -617,6 +617,7 @@ describe('HTTP Exception Handling', function() {
         httpExcLogger.debug('The second line');
         setTimeout(function() {
             assert(whenSuccessConnection - thisSendTime < retryTimeout);
+            assert(httpExcLogger._attempts === 0)
             done();
         }, retryTimeout + 200);
     });

--- a/test/logger.js
+++ b/test/logger.js
@@ -617,7 +617,7 @@ describe('HTTP Exception Handling', function() {
         httpExcLogger.debug('The second line');
         setTimeout(function() {
             assert(whenSuccessConnection - thisSendTime < retryTimeout);
-            assert(httpExcLogger._attempts === 0)
+            assert(httpExcLogger._attempts === 0);
             done();
         }, retryTimeout + 200);
     });

--- a/test/logger.js
+++ b/test/logger.js
@@ -587,7 +587,6 @@ describe('HTTP Exception Handling', function() {
     });
     it('when fails to connect, it should retry only three times and save the log until the next one comes in', function(done) {
         this.timeout(retryTimeout * 3 + 400);
-        //const failedLogger = Logger.createLogger(testHelper.apikey, options);
         let logSentTime = Date.now();
         httpExcLogger.debug('The line');
 

--- a/test/testHelper.js
+++ b/test/testHelper.js
@@ -103,6 +103,7 @@ module.exports.createOptions = function({
     , failedBufRetentionLimit = null
     , retryTimeout = null
     , flushInterval = null
+    , retryTimes = 3
     , shimProperties
 } = {}) {
     return {
@@ -116,6 +117,7 @@ module.exports.createOptions = function({
         , failedBufRetentionLimit: failedBufRetentionLimit
         , retryTimeout: retryTimeout
         , flushInterval: flushInterval
+        , retryTimes
         , shimProperties
     };
 };


### PR DESCRIPTION
Previously: when the logger fails to send a log, it saved the message in the buffer and attempts to send it only after receiving the next log. 

Now: when the logger fails to send a log, it tries to send it three times (after backoff period is passed) without waiting for the next log to come. If it fails to send it three (configurable) times, it saves it in the buffer and attempts again when the next message comes. 